### PR TITLE
Add MacOS thread names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Added
+-[PR#32](https://github.com/rust-minidump/minidump-writer/pull/32) resolved [#23](https://github.com/rust-minidump/minidump-writer/issues/23) by adding support for the thread names stream on MacOS.
+
 ## [0.2.0] - 2022-05-23
 ### Added
 - [PR#21](https://github.com/rust-minidump/minidump-writer/pull/21) added an initial implementation for `x86_64-apple-darwin` and `aarch64-apple-darwin`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 [dependencies]
 byteorder = "1.3.2"
 cfg-if = "1.0"
-crash-context = "0.2"
+crash-context = "0.3"
 memoffset = "0.6"
 minidump-common = "0.11"
 scroll = "0.11"
@@ -52,15 +52,11 @@ minidump = "0.11"
 memmap2 = "0.5"
 
 [target.'cfg(target_os = "macos")'.dev-dependencies]
-# # We dump symbols for the `test` executable so that we can validate that minidumps
-# # created by this crate can be processed by minidump-processor
-# dump_syms = { version = "0.0.7", default-features = false }
-# minidump-processor = { version = "0.11", default-features = false, features = [
-#     "breakpad-syms",
-# ] }
+# We dump symbols for the `test` executable so that we can validate that minidumps
+# created by this crate can be processed by minidump-processor
+dump_syms = { version = "0.0.7", default-features = false }
+minidump-processor = { version = "0.11", default-features = false, features = [
+    "breakpad-syms",
+] }
 similar-asserts = "1.2"
 uuid = "1.0"
-
-# [patch.crates-io]
-# # PR https://github.com/mozilla/dump_syms/pull/356, merged, but unreleased
-# dump_syms = { git = "https://github.com/mozilla/dump_syms", rev = "c2743d5" } # branch = master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,4 +62,5 @@ similar-asserts = "1.2"
 uuid = "1.0"
 
 [patch.crates-io]
+# PR: https://github.com/mozilla/dump_syms/pull/376
 dump_syms = { git = "https://github.com/EmbarkStudios/dump_syms", rev = "6531018" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,3 +60,6 @@ minidump-processor = { version = "0.11", default-features = false, features = [
 ] }
 similar-asserts = "1.2"
 uuid = "1.0"
+
+[patch.crates-io]
+dump_syms = { git = "https://github.com/EmbarkStudios/dump_syms", rev = "6531018" }

--- a/src/mac/mach.rs
+++ b/src/mac/mach.rs
@@ -290,6 +290,15 @@ pub trait TaskInfo {
     const FLAVOR: u32;
 }
 
+/// Minimal trait that just pairs a structure that can be filled out by
+/// [`thread_info`] with the "flavor" that tells it the info we
+/// actually want to retrieve
+pub trait ThreadInfo {
+    /// One of the `THREAD_*` integers. I assume it's very bad if you implement
+    /// this trait and provide the wrong flavor for the struct
+    const FLAVOR: u32;
+}
+
 /// <usr/include/mach-o/loader.h>, the file type for the main executable image
 pub const MH_EXECUTE: u32 = 0x2;
 // usr/include/mach-o/loader.h, magic number for MachHeader
@@ -571,8 +580,11 @@ extern "C" {
 
     /// Fomr <user/include/mach/thread_act.h>, this retrieves thread info for the
     /// for the specified thread.
+    ///
+    /// Note that the info_size parameter is actually the size of the thread_info / 4
+    /// as it is the number of words in the thread info
     pub fn thread_info(
-        thread: mach_port_t,
+        thread: u32,
         flavor: i32,
         thread_info: *mut i32,
         info_size: *mut u32,

--- a/src/mac/mach.rs
+++ b/src/mac/mach.rs
@@ -585,7 +585,7 @@ extern "C" {
     /// as it is the number of words in the thread info
     pub fn thread_info(
         thread: u32,
-        flavor: i32,
+        flavor: u32,
         thread_info: *mut i32,
         info_size: *mut u32,
     ) -> kern_return_t;

--- a/src/mac/mach.rs
+++ b/src/mac/mach.rs
@@ -568,4 +568,13 @@ extern "C" {
     /// Apple, there is no mention of a replacement function or when/if it might
     /// eventually disappear.
     pub fn pid_for_task(task: mach_port_name_t, pid: *mut i32) -> kern_return_t;
+
+    /// Fomr <user/include/mach/thread_act.h>, this retrieves thread info for the
+    /// for the specified thread.
+    pub fn thread_info(
+        thread: mach_port_t,
+        flavor: i32,
+        thread_info: *mut i32,
+        info_size: *mut u32,
+    ) -> kern_return_t;
 }

--- a/src/mac/minidump_writer.rs
+++ b/src/mac/minidump_writer.rs
@@ -24,6 +24,7 @@ impl MinidumpWriter {
         Self {
             crash_context,
             memory_blocks: Vec::new(),
+            threads: Vec::new(),
         }
     }
 
@@ -92,7 +93,7 @@ impl MinidumpWriter {
     /// Retrieves the list of active threads in the target process, but removes
     /// the handler thread if it is known to simplify dump analysis
     #[inline]
-    fn threads(&mut self, dumper: &TaskDumper) -> &[u32] {
+    pub(crate) fn threads(&mut self, dumper: &TaskDumper) -> &[u32] {
         if self.threads.is_empty() {
             if let Ok(threads) = dumper.read_threads() {
                 self.threads = threads.into();

--- a/src/mac/minidump_writer.rs
+++ b/src/mac/minidump_writer.rs
@@ -37,6 +37,7 @@ impl MinidumpWriter {
                 Box::new(|mw, buffer, dumper| mw.write_module_list(buffer, dumper)),
                 Box::new(|mw, buffer, dumper| mw.write_misc_info(buffer, dumper)),
                 Box::new(|mw, buffer, dumper| mw.write_breakpad_info(buffer, dumper)),
+                Box::new(|mw, buffer, dumper| mw.write_thread_names(buffer, dumper)),
             ];
 
             // Exception stream needs to be the last entry in this array as it may

--- a/src/mac/minidump_writer.rs
+++ b/src/mac/minidump_writer.rs
@@ -107,7 +107,7 @@ pub(crate) struct ActiveThreads {
 
 impl ActiveThreads {
     #[inline]
-    pub(crate) fn count(&self) -> usize {
+    pub(crate) fn len(&self) -> usize {
         let mut len = self.threads.len();
 
         if self.handler_thread != mach2::port::MACH_PORT_NULL {

--- a/src/mac/streams.rs
+++ b/src/mac/streams.rs
@@ -5,6 +5,7 @@ mod misc_info;
 mod module_list;
 mod system_info;
 mod thread_list;
+mod thread_names;
 
 use super::{
     errors::WriterError,

--- a/src/mac/streams/thread_list.rs
+++ b/src/mac/streams/thread_list.rs
@@ -18,7 +18,7 @@ impl MinidumpWriter {
             location: list_header.location(),
         };
 
-        let mut thread_list = MemoryArrayWriter::<MDRawThread>::alloc_array(buffer, thread_count)?;
+        let mut thread_list = MemoryArrayWriter::<MDRawThread>::alloc_array(buffer, threads.len())?;
         dirent.location.data_size += thread_list.location().data_size;
 
         for (i, tid) in threads.iter().enumerate() {

--- a/src/mac/streams/thread_list.rs
+++ b/src/mac/streams/thread_list.rs
@@ -11,17 +11,18 @@ impl MinidumpWriter {
     ) -> Result<MDRawDirectory, WriterError> {
         let threads = self.threads(dumper);
 
-        let list_header = MemoryWriter::<u32>::alloc_with_val(buffer, threads.len() as u32)?;
+        let list_header = MemoryWriter::<u32>::alloc_with_val(buffer, threads.count() as u32)?;
 
         let mut dirent = MDRawDirectory {
             stream_type: MDStreamType::ThreadListStream as u32,
             location: list_header.location(),
         };
 
-        let mut thread_list = MemoryArrayWriter::<MDRawThread>::alloc_array(buffer, threads.len())?;
+        let mut thread_list =
+            MemoryArrayWriter::<MDRawThread>::alloc_array(buffer, threads.count())?;
         dirent.location.data_size += thread_list.location().data_size;
 
-        for (i, tid) in threads.iter().enumerate() {
+        for (i, tid) in threads.enumerate() {
             let thread = self.write_thread(*tid, buffer, dumper)?;
             thread_list.set_value_at(buffer, thread, i)?;
         }

--- a/src/mac/streams/thread_list.rs
+++ b/src/mac/streams/thread_list.rs
@@ -23,7 +23,7 @@ impl MinidumpWriter {
         dirent.location.data_size += thread_list.location().data_size;
 
         for (i, tid) in threads.enumerate() {
-            let thread = self.write_thread(*tid, buffer, dumper)?;
+            let thread = self.write_thread(tid, buffer, dumper)?;
             thread_list.set_value_at(buffer, thread, i)?;
         }
 

--- a/src/mac/streams/thread_list.rs
+++ b/src/mac/streams/thread_list.rs
@@ -11,15 +11,14 @@ impl MinidumpWriter {
     ) -> Result<MDRawDirectory, WriterError> {
         let threads = self.threads(dumper);
 
-        let list_header = MemoryWriter::<u32>::alloc_with_val(buffer, threads.count() as u32)?;
+        let list_header = MemoryWriter::<u32>::alloc_with_val(buffer, threads.len() as u32)?;
 
         let mut dirent = MDRawDirectory {
             stream_type: MDStreamType::ThreadListStream as u32,
             location: list_header.location(),
         };
 
-        let mut thread_list =
-            MemoryArrayWriter::<MDRawThread>::alloc_array(buffer, threads.count())?;
+        let mut thread_list = MemoryArrayWriter::<MDRawThread>::alloc_array(buffer, threads.len())?;
         dirent.location.data_size += thread_list.location().data_size;
 
         for (i, tid) in threads.enumerate() {

--- a/src/mac/streams/thread_names.rs
+++ b/src/mac/streams/thread_names.rs
@@ -73,7 +73,7 @@ impl MinidumpWriter {
             thread_info.pth_name.as_ptr().cast(),
             thread_info.pth_name.len(),
         )))
-        .map_err(|err| TaskDumpError::from(err))?;
+        .unwrap_or_default();
 
         // Ignore the null terminator
         let tname = match name.find('\0') {

--- a/src/mac/streams/thread_names.rs
+++ b/src/mac/streams/thread_names.rs
@@ -1,0 +1,88 @@
+use super::*;
+
+impl MinidumpWriter {
+    /// Writes the [`MDStreamType::ThreadNamesStream`] which is an array of
+    /// [`miniduimp_common::format::MINIDUMP_THREAD`]
+    pub(crate) fn write_thread_names(
+        &mut self,
+        buffer: &mut DumpBuf,
+        dumper: &TaskDumper,
+    ) -> Result<MDRawDirectory, WriterError> {
+        let threads = dumper.read_threads()?;
+
+        // Ignore the thread that handled the exception
+        let thread_count = if self.crash_context.handler_thread != mach2::port::MACH_PORT_NULL {
+            threads.len() - 1
+        } else {
+            threads.len()
+        };
+
+        let list_header = MemoryWriter::<u32>::alloc_with_val(buffer, thread_count as u32)?;
+
+        let mut dirent = MDRawDirectory {
+            stream_type: MDStreamType::ThreadNamesStream as u32,
+            location: list_header.location(),
+        };
+
+        let mut names = MemoryArrayWriter::<MDRawThreadName>::alloc_array(buffer, thread_count)?;
+        dirent.location.data_size += names.location().data_size;
+
+        let handler_thread = self.crash_context.handler_thread;
+        for (i, tid) in threads
+            .iter()
+            .filter(|tid| **tid != handler_thread)
+            .enumerate()
+        {
+            // It's unfortunate if we can't grab a thread name, but it's also
+            // not a critical failure
+            let name_loc = match Self::write_thread_name(buffer, *tid) {
+                Some(loc) => loc,
+                None => write_string_to_location(buffer, "")?,
+            };
+
+            let thread = MDRawThreadName {
+                thread_id: *tid,
+                thread_name_rva: name_loc.rva.into(),
+            };
+
+            names.set_value_at(buffer, thread, i)?;
+        }
+
+        Ok(dirent)
+    }
+
+    /// Attempts to retrieve and write the threadname, returning the threa names
+    /// location if successful
+    fn write_thread_name(buffer: &mut Buffer, tid: u32) -> Option<MDLocationDescriptor> {
+        // SAFETY: syscalls
+        unsafe {
+            let mut thread_info = std::mem::MaybeUninit::<libc::proc_threadinfo>::uninit();
+            let size = std::mem::size_of::<libc::proc_threadinfo>() as i32;
+            if libc::proc_pidinfo(
+                tid as _,
+                libc::PROC_PIDTHREADINFO,
+                0,
+                thread_info.as_mut_ptr().cast(),
+                size,
+            ) == size
+            {
+                let thread_info = thread_info.assume_init();
+                let name = std::str::from_utf8(std::slice::from_raw_parts(
+                    thread_info.pth_name.as_ptr().cast(),
+                    thread_info.pth_name.len(),
+                ))
+                .ok()?;
+
+                // Ignore the null terminator
+                let tname = match name.find('\0') {
+                    Some(i) => &name[..i],
+                    None => name,
+                };
+
+                write_string_to_location(buffer, tname).ok()
+            } else {
+                None
+            }
+        }
+    }
+}

--- a/src/mac/streams/thread_names.rs
+++ b/src/mac/streams/thread_names.rs
@@ -17,7 +17,7 @@ impl MinidumpWriter {
             location: list_header.location(),
         };
 
-        let mut names = MemoryArrayWriter::<MDRawThreadName>::alloc_array(buffer, thread_count)?;
+        let mut names = MemoryArrayWriter::<MDRawThreadName>::alloc_array(buffer, threads.len())?;
         dirent.location.data_size += names.location().data_size;
 
         for (i, tid) in threads.iter().enumerate() {

--- a/src/mac/streams/thread_names.rs
+++ b/src/mac/streams/thread_names.rs
@@ -58,19 +58,19 @@ impl MinidumpWriter {
         unsafe {
             let mut thread_info = std::mem::MaybeUninit::<libc::proc_threadinfo>::uninit();
             let size = std::mem::size_of::<libc::proc_threadinfo>() as i32;
-            if libc::proc_pidinfo(
-                tid as _,
+            if dbg!(libc::proc_pidinfo(
+                dbg!(tid as _),
                 libc::PROC_PIDTHREADINFO,
                 0,
                 thread_info.as_mut_ptr().cast(),
                 size,
-            ) == size
+            )) == size
             {
                 let thread_info = thread_info.assume_init();
-                let name = std::str::from_utf8(std::slice::from_raw_parts(
+                let name = dbg!(std::str::from_utf8(std::slice::from_raw_parts(
                     thread_info.pth_name.as_ptr().cast(),
                     thread_info.pth_name.len(),
-                ))
+                )))
                 .ok()?;
 
                 // Ignore the null terminator

--- a/src/mac/streams/thread_names.rs
+++ b/src/mac/streams/thread_names.rs
@@ -36,8 +36,11 @@ impl MinidumpWriter {
             // It's unfortunate if we can't grab a thread name, but it's also
             // not a critical failure
             let name_loc = match Self::write_thread_name(buffer, *tid) {
-                Some(loc) => loc,
-                None => write_string_to_location(buffer, "")?,
+                Ok(loc) => loc,
+                Err(_err) => {
+                    // TODO: log error
+                    write_string_to_location(buffer, "")?
+                }
             };
 
             let thread = MDRawThreadName {
@@ -56,7 +59,7 @@ impl MinidumpWriter {
     fn write_thread_name(
         buffer: &mut Buffer,
         tid: u32,
-    ) -> Result<MDLocationDescriptor, TaskDumpError> {
+    ) -> Result<MDLocationDescriptor, WriterError> {
         const THREAD_INFO_COUNT: u32 =
             (std::mem::size_of::<libc::proc_threadinfo>() / std::mem::size_of::<u32>()) as u32;
 

--- a/src/mac/streams/thread_names.rs
+++ b/src/mac/streams/thread_names.rs
@@ -69,15 +69,15 @@ impl MinidumpWriter {
 
         let thread_info: libc::proc_threadinfo = dumper.thread_info(tid)?;
 
-        let name = dbg!(std::str::from_utf8(
+        let name = std::str::from_utf8(
             // SAFETY: This is an initialized block of static size
             unsafe {
                 std::slice::from_raw_parts(
                     thread_info.pth_name.as_ptr().cast(),
                     thread_info.pth_name.len(),
                 )
-            }
-        ))
+            },
+        )
         .unwrap_or_default();
 
         // Ignore the null terminator

--- a/src/mac/streams/thread_names.rs
+++ b/src/mac/streams/thread_names.rs
@@ -23,7 +23,7 @@ impl MinidumpWriter {
         for (i, tid) in threads.enumerate() {
             // It's unfortunate if we can't grab a thread name, but it's also
             // not a critical failure
-            let name_loc = match Self::write_thread_name(buffer, dumper, *tid) {
+            let name_loc = match Self::write_thread_name(buffer, dumper, tid) {
                 Ok(loc) => loc,
                 Err(_err) => {
                     // TODO: log error
@@ -32,7 +32,7 @@ impl MinidumpWriter {
             };
 
             let thread = MDRawThreadName {
-                thread_id: *tid,
+                thread_id: tid,
                 thread_name_rva: name_loc.rva.into(),
             };
 

--- a/src/mac/streams/thread_names.rs
+++ b/src/mac/streams/thread_names.rs
@@ -10,14 +10,14 @@ impl MinidumpWriter {
     ) -> Result<MDRawDirectory, WriterError> {
         let threads = self.threads(dumper);
 
-        let list_header = MemoryWriter::<u32>::alloc_with_val(buffer, threads.count() as u32)?;
+        let list_header = MemoryWriter::<u32>::alloc_with_val(buffer, threads.len() as u32)?;
 
         let mut dirent = MDRawDirectory {
             stream_type: MDStreamType::ThreadNamesStream as u32,
             location: list_header.location(),
         };
 
-        let mut names = MemoryArrayWriter::<MDRawThreadName>::alloc_array(buffer, threads.count())?;
+        let mut names = MemoryArrayWriter::<MDRawThreadName>::alloc_array(buffer, threads.len())?;
         dirent.location.data_size += names.location().data_size;
 
         for (i, tid) in threads.enumerate() {

--- a/src/mac/streams/thread_names.rs
+++ b/src/mac/streams/thread_names.rs
@@ -10,17 +10,17 @@ impl MinidumpWriter {
     ) -> Result<MDRawDirectory, WriterError> {
         let threads = self.threads(dumper);
 
-        let list_header = MemoryWriter::<u32>::alloc_with_val(buffer, threads.len() as u32)?;
+        let list_header = MemoryWriter::<u32>::alloc_with_val(buffer, threads.count() as u32)?;
 
         let mut dirent = MDRawDirectory {
             stream_type: MDStreamType::ThreadNamesStream as u32,
             location: list_header.location(),
         };
 
-        let mut names = MemoryArrayWriter::<MDRawThreadName>::alloc_array(buffer, threads.len())?;
+        let mut names = MemoryArrayWriter::<MDRawThreadName>::alloc_array(buffer, threads.count())?;
         dirent.location.data_size += names.location().data_size;
 
-        for (i, tid) in threads.iter().enumerate() {
+        for (i, tid) in threads.enumerate() {
             // It's unfortunate if we can't grab a thread name, but it's also
             // not a critical failure
             let name_loc = match Self::write_thread_name(buffer, dumper, *tid) {

--- a/src/mac/streams/thread_names.rs
+++ b/src/mac/streams/thread_names.rs
@@ -69,10 +69,15 @@ impl MinidumpWriter {
 
         let thread_info: libc::proc_threadinfo = dumper.thread_info(tid)?;
 
-        let name = dbg!(std::str::from_utf8(std::slice::from_raw_parts(
-            thread_info.pth_name.as_ptr().cast(),
-            thread_info.pth_name.len(),
-        )))
+        let name = dbg!(std::str::from_utf8(
+            // SAFETY: This is an initialized block of static size
+            unsafe {
+                std::slice::from_raw_parts(
+                    thread_info.pth_name.as_ptr().cast(),
+                    thread_info.pth_name.len(),
+                )
+            }
+        ))
         .unwrap_or_default();
 
         // Ignore the null terminator

--- a/tests/mac_minidump_writer.rs
+++ b/tests/mac_minidump_writer.rs
@@ -196,7 +196,7 @@ fn stackwalks() {
 
     assert_eq!(
         fake_crash_thread.thread_name.as_deref(),
-        Some("test-thread")
+        Some("test-thread-just-for-giggles")
     );
 
     assert!(

--- a/tests/mac_minidump_writer.rs
+++ b/tests/mac_minidump_writer.rs
@@ -196,7 +196,7 @@ fn stackwalks() {
 
     assert_eq!(
         fake_crash_thread.thread_name.as_deref(),
-        Some("test-thread-just-for-giggles")
+        Some("test-thread")
     );
 
     assert!(

--- a/tests/mac_minidump_writer.rs
+++ b/tests/mac_minidump_writer.rs
@@ -156,7 +156,13 @@ fn stackwalks() {
             symbol_server: None,
             debug_id: None,
             code_id: None,
-            arch: "",
+            arch: if cfg!(target_arch = "aarch64") {
+                "aarch64"
+            } else if cfg!(target_arch = "x86_64") {
+                "x86_64"
+            } else {
+                panic!("invalid MacOS target architecture")
+            },
             file_type: dump_syms::common::FileType::Macho,
             num_jobs: 2, // default this
             check_cfi: false,

--- a/tests/mac_minidump_writer.rs
+++ b/tests/mac_minidump_writer.rs
@@ -157,7 +157,7 @@ fn stackwalks() {
             debug_id: None,
             code_id: None,
             arch: if cfg!(target_arch = "aarch64") {
-                "aarch64"
+                "arm64"
             } else if cfg!(target_arch = "x86_64") {
                 "x86_64"
             } else {


### PR DESCRIPTION
I wanted to use `proc_pidinfo` for this since apparently it is possible, but was apparently missing something and the calls failed (maybe need to convert the mach port to a BSD/posix thread id?), so for now this uses the mach `thread_info` to retrieve the thread names.

Note this depends on a change to dump_syms that I noticed when testing, will file a PR for that now as well.

Resolves: #23 
