### PR TITLE
Fix stack pointer recording for aarch64 Linux

### DIFF
--- a/src/linux/thread_info/aarch64.rs
+++ b/src/linux/thread_info/aarch64.rs
@@ -116,7 +116,7 @@ impl ThreadInfoAarch64 {
         let regs = Self::getregs(tid)?;
         let fpregs = Self::getfpregs(tid)?;
 
-        let stack_pointer = regs.regs[13] as usize;
+        let stack_pointer = regs.sp as usize;
 
         Ok(Self {
             stack_pointer,


### PR DESCRIPTION
Register 13 is the stack pointer on 32 bit ARM, but on 64 bit ARM it's stored separately.