### PR TITLE
Fix mac modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Fixed
+- [PR#42](https://github.com/rust-minidump/minidump-writer/pull/42) resolved [#41](https://github.com/rust-minidump/minidump-writer/issues/41) by capping the VM read of task memory to avoid a syscall failure, as well as made it so that if an error does occur when reading the module's file path, the module is still written to the minidump, as the file path is less important than the UUID.
+
 ## [0.2.1] - 2022-05-25
 ### Added
 - [PR#32](https://github.com/rust-minidump/minidump-writer/pull/32) resolved [#23](https://github.com/rust-minidump/minidump-writer/issues/23) by adding support for the thread names stream on MacOS.

--- a/src/mac/streams/module_list.rs
+++ b/src/mac/streams/module_list.rs
@@ -132,7 +132,10 @@ impl MinidumpWriter {
         })?;
 
         let file_path = if image.file_path != 0 {
-            dumper.read_string(image.file_path)?.unwrap_or_default()
+            dumper
+                .read_string(image.file_path)
+                .unwrap_or_default()
+                .unwrap_or_default()
         } else {
             String::new()
         };

--- a/src/mac/task_dumper.rs
+++ b/src/mac/task_dumper.rs
@@ -197,7 +197,8 @@ impl TaskDumper {
         };
 
         if let Ok(size_to_end) = get_region_size() {
-            let mut bytes = self.read_task_memory(addr, size_to_end as usize)?;
+            let mut bytes =
+                self.read_task_memory(addr, std::cmp::min(size_to_end as usize, 8 * 1024))?;
 
             // Find the null terminator and truncate our string
             if let Some(null_pos) = bytes.iter().position(|c| *c == 0) {


### PR DESCRIPTION
When iterating over the loaded module to gather their metadata, only the main executable file path was being read correctly due to an oversight in the reading of the task memory, causing the read to fail and the module to be skipped and not written to the minidump. Now the file path is capped to a generous 8k, the same as Breakpad, which no longer runs into the issue. I also made it so that failing to read the file path for the module won't skip the module entirely any longer since that is rather harsh.

Resolves: #41