### PR TITLE
Fix mac module load address

### DIFF
--- a/src/mac.rs
+++ b/src/mac.rs
@@ -3,6 +3,9 @@
 #[cfg(target_pointer_width = "32")]
 compile_error!("Various MacOS FFI bindings assume we are on a 64-bit architechture");
 
+/// Re-export of the mach2 library for users who want to call mach specific functions
+pub use mach2;
+
 pub mod errors;
 pub mod mach;
 pub mod minidump_writer;

--- a/src/mac/errors.rs
+++ b/src/mac/errors.rs
@@ -8,4 +8,6 @@ pub enum WriterError {
     MemoryWriterError(#[from] crate::mem_writer::MemoryWriterError),
     #[error("Failed to write to file")]
     FileWriterError(#[from] crate::dir_section::FileWriterError),
+    #[error("Attempted to write an exception stream with no crash context")]
+    NoCrashContext,
 }

--- a/src/mac/minidump_writer.rs
+++ b/src/mac/minidump_writer.rs
@@ -25,6 +25,21 @@ pub struct MinidumpWriter {
 impl MinidumpWriter {
     /// Creates a minidump writer for the specified mach task (process) and
     /// handler thread. If not specified, defaults to the current task and thread.
+    ///
+    /// ```
+    /// use minidump_writer::{minidump_writer::MinidumpWriter, mach2};
+    ///
+    /// // Note that this is the same as specifying `None` for both the task and
+    /// // handler thread, this is just meant to illustrate how you can setup
+    /// // a MinidumpWriter manually instead of using a `CrashContext`
+    /// // SAFETY: syscalls
+    /// let mdw = unsafe {
+    ///     MinidumpWriter::new(
+    ///         Some(mach2::traps::mach_task_self()),
+    ///         Some(mach2::mach_init::mach_thread_self()),
+    ///     )
+    /// };
+    /// ```
     pub fn new(task: Option<task_t>, handler_thread: Option<thread_t>) -> Self {
         Self {
             crash_context: None,
@@ -54,6 +69,8 @@ impl MinidumpWriter {
         }
     }
 
+    /// Writes a minidump to the specified destination, returning the raw minidump
+    /// contents upon success
     pub fn dump(&mut self, destination: &mut (impl Write + Seek)) -> Result<Vec<u8>> {
         let writers = {
             #[allow(clippy::type_complexity)]

--- a/src/mac/streams/breakpad_info.rs
+++ b/src/mac/streams/breakpad_info.rs
@@ -20,9 +20,9 @@ impl MinidumpWriter {
                     | BreakpadInfoValid::RequestingThreadId.bits(),
                 // The thread where the exception port handled the exception, might
                 // be useful to ignore/deprioritize when processing the minidump
-                dump_thread_id: self.crash_context.handler_thread,
+                dump_thread_id: self.handler_thread,
                 // The actual thread where the exception was thrown
-                requesting_thread_id: self.crash_context.thread,
+                requesting_thread_id: self.crash_context.as_ref().map(|cc| cc.thread).unwrap_or(0),
             },
         )?;
 

--- a/src/mac/streams/memory_list.rs
+++ b/src/mac/streams/memory_list.rs
@@ -11,44 +11,47 @@ impl MinidumpWriter {
     ) -> Result<MDRawDirectory, WriterError> {
         // Include some memory around the instruction pointer if the crash was
         // due to an exception
-        if self.crash_context.exception.is_some() {
-            const IP_MEM_SIZE: u64 = 256;
+        if let Some(cc) = &self.crash_context {
+            if cc.exception.is_some() {
+                const IP_MEM_SIZE: u64 = 256;
 
-            let get_ip_block = |tid| -> Option<std::ops::Range<u64>> {
-                let thread_state = dumper.read_thread_state(tid).ok()?;
+                let get_ip_block = |tid| -> Option<std::ops::Range<u64>> {
+                    let thread_state = dumper.read_thread_state(tid).ok()?;
 
-                let ip = thread_state.pc();
+                    let ip = thread_state.pc();
 
-                // Bound it to the upper and lower bounds of the region
-                // it's contained within. If it's not in a known memory region,
-                // don't bother trying to write it.
-                let region = dumper.get_vm_region(ip).ok()?;
+                    // Bound it to the upper and lower bounds of the region
+                    // it's contained within. If it's not in a known memory region,
+                    // don't bother trying to write it.
+                    let region = dumper.get_vm_region(ip).ok()?;
 
-                if ip < region.range.start || ip > region.range.end {
-                    return None;
-                }
+                    if ip < region.range.start || ip > region.range.end {
+                        return None;
+                    }
 
-                // Try to get IP_MEM_SIZE / 2 bytes before and after the IP, but
-                // settle for whatever's available.
-                let start = std::cmp::max(region.range.start, ip - IP_MEM_SIZE / 2);
-                let end = std::cmp::min(ip + IP_MEM_SIZE / 2, region.range.end);
+                    // Try to get IP_MEM_SIZE / 2 bytes before and after the IP, but
+                    // settle for whatever's available.
+                    let start = std::cmp::max(region.range.start, ip - IP_MEM_SIZE / 2);
+                    let end = std::cmp::min(ip + IP_MEM_SIZE / 2, region.range.end);
 
-                Some(start..end)
-            };
-
-            if let Some(ip_range) = get_ip_block(self.crash_context.thread) {
-                let size = ip_range.end - ip_range.start;
-                let stack_buffer = dumper.read_task_memory(ip_range.start as _, size as usize)?;
-                let ip_location = MDLocationDescriptor {
-                    data_size: size as u32,
-                    rva: buffer.position() as u32,
+                    Some(start..end)
                 };
-                buffer.write_all(&stack_buffer);
 
-                self.memory_blocks.push(MDMemoryDescriptor {
-                    start_of_memory_range: ip_range.start,
-                    memory: ip_location,
-                });
+                if let Some(ip_range) = get_ip_block(cc.thread) {
+                    let size = ip_range.end - ip_range.start;
+                    let stack_buffer =
+                        dumper.read_task_memory(ip_range.start as _, size as usize)?;
+                    let ip_location = MDLocationDescriptor {
+                        data_size: size as u32,
+                        rva: buffer.position() as u32,
+                    };
+                    buffer.write_all(&stack_buffer);
+
+                    self.memory_blocks.push(MDMemoryDescriptor {
+                        start_of_memory_range: ip_range.start,
+                        memory: ip_location,
+                    });
+                }
             }
         }
 

--- a/tests/mac_minidump_writer.rs
+++ b/tests/mac_minidump_writer.rs
@@ -52,7 +52,7 @@ fn capture_minidump(name: &str, exception_kind: u32) -> Captured<'_> {
     let task = rcc.crash_context.task;
     let thread = rcc.crash_context.thread;
 
-    let mut dumper = MinidumpWriter::new(rcc.crash_context);
+    let mut dumper = MinidumpWriter::with_crash_context(rcc.crash_context);
 
     dumper
         .dump(tmpfile.as_file_mut())


### PR DESCRIPTION
- Fix module base address by always using a correct slide
- Make mac crash context optional
- Add some more API documentation

When calculating the image slide, the difference between the image's preferred load address and the TEXT segment, we faithfullly ported the Breakpad implementation:

## breakpad

https://github.com/google/breakpad/blob/335e61656fa6034fabc3431a91e5800ba6fc3dc9/src/client/mac/handler/dynamic_images.cc#L269-L272

## minidump-writer

https://github.com/rust-minidump/minidump-writer/blob/1a1e912e98d59751840b8e2c56ff3b6228134678/src/mac/streams/module_list.rs#L97-L101

This was, however, a mistake, as that logic was just incorrect as shown by the crashpad implementation

## crashpad

https://github.com/chromium/crashpad/blob/df86075acc33314e611b351b33bf1c671b8cbc2f/snapshot/mac/mach_o_image_reader.cc#L585-L589

When removing the if and unconditionally calculating the slide, the `images_match` test that I added started passing which gives me a bit more confidence that the implementation is (more) correct now than the one copied from Breakpad.

While I was here, the test code needed a bit of refactoring in the minidumpwriter since that was easier than pulling out the logic into a reusable piece (it's maybe a good idea to do....but I also don't want us to end up in a crashpad scenario with a mountain of obtuse abstractions), so this addresses the Mac part of #37, and I'll do the same for Windows in a separate PR to close the issue.

Part of: #37 
Resolves: #43 