### PR TITLE
Make `dir_section` and `mem_writer` modules public

### DIFF
--- a/examples/synthetic.rs
+++ b/examples/synthetic.rs
@@ -1,0 +1,36 @@
+//! Emits default minidump with no streams to specified path
+
+use std::fs::File;
+
+use minidump_writer::{
+    dir_section::DirSection,
+    mem_writer::{Buffer, MemoryWriter},
+    minidump_format::{MDRawHeader, MD_HEADER_SIGNATURE, MD_HEADER_VERSION},
+};
+
+// usage: `cargo run --example synthetic /tmp/micro-minidump.dmp`
+fn main() {
+    let output_path = std::env::args()
+        .nth(1)
+        .expect("missing argument: output file path");
+
+    let num_writers = 0u32;
+    let buffer_capacity = 32;
+
+    let mut destination = File::create(output_path).expect("failed to create file");
+    let mut buffer = Buffer::with_capacity(buffer_capacity);
+    let mut header_section = MemoryWriter::<MDRawHeader>::alloc(&mut buffer).unwrap();
+    let mut dir_section = DirSection::new(&mut buffer, num_writers, &mut destination).unwrap();
+
+    let header = MDRawHeader {
+        signature: MD_HEADER_SIGNATURE,
+        version: MD_HEADER_VERSION,
+        stream_count: num_writers,
+        stream_directory_rva: dir_section.position(),
+        checksum: 0,
+        time_date_stamp: 0u32,
+        flags: 0,
+    };
+    header_section.set_value(&mut buffer, header).unwrap();
+    dir_section.write_to_file(&mut buffer, None).unwrap();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,11 +17,5 @@ cfg_if::cfg_if! {
 pub mod minidump_cpu;
 pub mod minidump_format;
 
-// Non-windows platforms need additional code since they are essentially
-// replicating functionality we get for free on Windows
-cfg_if::cfg_if! {
-    if #[cfg(not(target_os = "windows"))] {
-        pub(crate) mod mem_writer;
-        pub(crate) mod dir_section;
-    }
-}
+pub mod dir_section;
+pub mod mem_writer;

--- a/src/linux/app_memory.rs
+++ b/src/linux/app_memory.rs
@@ -1,6 +1,6 @@
 // These entries store a list of memory regions that the client wants included
 // in the minidump.
-#[derive(Debug, Default, PartialEq)]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub struct AppMemory {
     pub ptr: usize,
     pub length: usize,

--- a/src/linux/auxv_reader.rs
+++ b/src/linux/auxv_reader.rs
@@ -19,7 +19,7 @@ pub type AuxvType = u32;
 pub type AuxvType = u64;
 
 /// An auxv key-value pair.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct AuxvPair {
     pub key: AuxvType,
     pub value: AuxvType,
@@ -38,7 +38,7 @@ impl ProcfsAuxvIter {
         let pair_size = 2 * std::mem::size_of::<AuxvType>();
         let buf: Vec<u8> = Vec::with_capacity(pair_size);
 
-        ProcfsAuxvIter {
+        Self {
             pair_size,
             buf,
             input,

--- a/src/linux/maps_reader.rs
+++ b/src/linux/maps_reader.rs
@@ -12,7 +12,7 @@ pub const RESERVED_FLAGS: &str = "---p";
 
 type Result<T> = std::result::Result<T, MapsReaderError>;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct SystemMappingInfo {
     pub start_address: usize,
     pub end_address: usize,
@@ -20,7 +20,7 @@ pub struct SystemMappingInfo {
 
 // One of these is produced for each mapping in the process (i.e. line in
 // /proc/$x/maps).
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct MappingInfo {
     // On Android, relocation packing can mean that the reported start
     // address of the mapping must be adjusted by a bias in order to

--- a/src/mem_writer.rs
+++ b/src/mem_writer.rs
@@ -88,7 +88,7 @@ impl std::ops::Deref for Buffer {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct MemoryWriter<T> {
     pub position: MDRVA,
     pub size: usize,
@@ -139,7 +139,7 @@ where
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct MemoryArrayWriter<T> {
     pub position: MDRVA,
     array_size: usize,


### PR DESCRIPTION
I plan to construct minidumps from other data sources, so having access to types provided by these modules would be helpful.

Based on the current public API it seems the primary use case of `minidump-writer` is to construct a minidump by introspecting on the current execution environment.

Could you support this use case, either by adopting this change or working with me to find another solution?