### PR TITLE
Update the rust-minidump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ byteorder = "1.3.2"
 cfg-if = "1.0"
 crash-context = "0.5"
 memoffset = "0.7"
-minidump-common = "0.14"
+minidump-common = "0.15"
 scroll = "0.11"
 tempfile = "3.1.0"
 thiserror = "1.0.21"
@@ -44,13 +44,13 @@ features = ["minwindef", "processthreadsapi", "winnt"]
 [dev-dependencies]
 # Minidump-processor is async so we need an executor
 futures = { version = "0.3", features = ["executor"] }
-minidump = "0.14"
+minidump = "0.15"
 memmap2 = "0.5"
 
 [target.'cfg(target_os = "macos")'.dev-dependencies]
 # We dump symbols for the `test` executable so that we can validate that minidumps
 # created by this crate can be processed by minidump-processor
 dump_syms = { version = "2.0.0", default-features = false }
-minidump-processor = { version = "0.14", default-features = false }
+minidump-processor = { version = "0.15", default-features = false }
 similar-asserts = "1.2"
 uuid = "1.0"


### PR DESCRIPTION
This makes the minidump-writer crate not depend anymore on the tracing crate (it becomes only a dev dependency) which reduces the footprint of the crate when it's being vendored.