### PR TITLE
Write stacks correctly during stack overflows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 license = "MIT"
 
 [dependencies]
+bitflags = "2.0"
 byteorder = "1.3.2"
 cfg-if = "1.0"
 crash-context = "0.6"

--- a/src/linux/android.rs
+++ b/src/linux/android.rs
@@ -118,7 +118,7 @@ pub fn late_process_mappings(pid: Pid, mappings: &mut [MappingInfo]) -> Result<(
     // where the ELF header indicates a mapped shared library.
     for mut map in mappings
         .iter_mut()
-        .filter(|m| m.executable && m.name_is_path())
+        .filter(|m| m.is_executable() && m.name_is_path())
     {
         let ehdr_opt = PtraceDumper::copy_from_process(
             pid,

--- a/src/linux/errors.rs
+++ b/src/linux/errors.rs
@@ -3,6 +3,7 @@ use crate::maps_reader::MappingInfo;
 use crate::mem_writer::MemoryWriterError;
 use crate::thread_info::Pid;
 use goblin;
+use nix::errno::Errno;
 use std::ffi::OsString;
 use thiserror::Error;
 
@@ -16,6 +17,8 @@ pub enum InitError {
     PrincipalMappingNotReferenced,
     #[error("Failed Android specific late init")]
     AndroidLateInitError(#[from] AndroidError),
+    #[error("Failed to read the page size")]
+    PageSizeError(#[from] Errno),
 }
 
 #[derive(Error, Debug)]

--- a/src/linux/minidump_writer.rs
+++ b/src/linux/minidump_writer.rs
@@ -156,15 +156,16 @@ impl MinidumpWriter {
             return true;
         }
 
-        let (stack_ptr, stack_len) = match dumper.get_stack_info(stack_pointer) {
+        let (valid_stack_pointer, stack_len) = match dumper.get_stack_info(stack_pointer) {
             Ok(x) => x,
             Err(_) => {
                 return false;
             }
         };
+
         let stack_copy = match PtraceDumper::copy_from_process(
             self.blamed_thread,
-            stack_ptr as *mut libc::c_void,
+            valid_stack_pointer as *mut libc::c_void,
             stack_len,
         ) {
             Ok(x) => x,
@@ -173,7 +174,7 @@ impl MinidumpWriter {
             }
         };
 
-        let sp_offset = stack_pointer - stack_ptr;
+        let sp_offset = stack_pointer.saturating_sub(valid_stack_pointer);
         self.principal_mapping
             .as_ref()
             .unwrap()

--- a/tests/ptrace_dumper.rs
+++ b/tests/ptrace_dumper.rs
@@ -39,9 +39,10 @@ fn test_thread_list_from_parent() {
         let info = dumper
             .get_thread_info_by_index(idx)
             .expect("Could not get thread info by index");
-        let (_stack_ptr, stack_len) = dumper
+        let (_valid_stack_ptr, stack_len) = dumper
             .get_stack_info(info.stack_pointer)
             .expect("Could not get stack_pointer");
+
         assert!(stack_len > 0);
 
         // TODO: I currently know of no way to write the thread_id into the registers using Rust,
@@ -259,7 +260,7 @@ fn test_sanitize_stack_copy() {
     let mapping_info = dumper
         .find_mapping_no_bias(instr_ptr)
         .expect("Failed to find mapping info");
-    assert!(mapping_info.executable);
+    assert!(mapping_info.is_executable());
 
     // Pointers to code shouldn't be sanitized.
     simulated_stack = vec![0u8; 2 * size_of::<usize>()];


### PR DESCRIPTION
When encountering a stack overflow we often crash accessing the guard page. The logic assumed that wherever the stack pointer was so was the stack, but this lead the writer to dump the guard page in these cases. This patch changes the logic to inspect the properties of the mapping that appears to correspond to the stack and - if it looks like a guard page - look for the actual stack instead.

This fixes #24