### PR TITLE
Avoid pulling in `chrono`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,8 @@ nix = { version = "0.26", default-features = false, features = [
     "user",
 ] }
 # Used for parsing procfs info.
-procfs-core = "0.16.0-RC1"
+# default-features is disabled since it pulls in chrono
+procfs-core = { version = "0.16.0-RC1", default-features = false }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 bitflags = "2.0"


### PR DESCRIPTION
By default `procfs-core` pulls in `chrono` which we've actually banned since it had vulnerabilities and was not actively maintained (though now is), but is regardless completely unneeded for what we use `procfs-core` for in this crate.