### PR TITLE
Cleanup .so version parsing

### DIFF
--- a/src/linux/sections/mappings.rs
+++ b/src/linux/sections/mappings.rs
@@ -83,24 +83,29 @@ fn fill_raw_module(
         sig_section.location()
     };
 
-    let (file_path, _, (major, minor, release)) = mapping
+    let (file_path, _, so_version) = mapping
         .get_mapping_effective_path_name_and_version()
         .map_err(|e| errors::SectionMappingsError::GetEffectivePathError(mapping.clone(), e))?;
     let name_header = write_string_to_location(buffer, file_path.to_string_lossy().as_ref())?;
 
-    let mut raw_module = MDRawModule {
+    let version_info = so_version.map_or(Default::default(), |sov| format::VS_FIXEDFILEINFO {
+        signature: format::VS_FFI_SIGNATURE,
+        struct_version: format::VS_FFI_STRUCVERSION,
+        file_version_hi: sov.major,
+        file_version_lo: sov.minor,
+        product_version_hi: sov.patch,
+        product_version_lo: sov.prerelease,
+        ..Default::default()
+    });
+
+    let raw_module = MDRawModule {
         base_of_image: mapping.start_address as u64,
         size_of_image: mapping.size as u32,
         cv_record,
         module_name_rva: name_header.rva,
+        version_info,
         ..Default::default()
     };
-
-    raw_module.version_info.signature = format::VS_FFI_SIGNATURE;
-    raw_module.version_info.struct_version = format::VS_FFI_STRUCVERSION;
-    raw_module.version_info.file_version_hi = major;
-    raw_module.version_info.file_version_lo = minor;
-    raw_module.version_info.product_version_hi = release;
 
     Ok(raw_module)
 }


### PR DESCRIPTION
Follow up to #103 

Replace opaque tuple with documented `SoVersion`, more cleanly handle the last version potentially having 2 numbers, and add a few test cases that seem possible.

@lissyx does this look ok to you?