### PR TITLE
Send SIGSTOP to linux/android processes before doing other procfs/ptrace things.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1226,6 +1226,7 @@ dependencies = [
  "futures",
  "goblin 0.8.0",
  "libc",
+ "log",
  "mach2",
  "memmap2",
  "memoffset",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
 name = "circular"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1295,12 +1301,13 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nix"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
  "bitflags 2.4.2",
  "cfg-if",
+ "cfg_aliases",
  "libc",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ bitflags = "2.4"
 byteorder = "1.4"
 cfg-if = "1.0"
 crash-context = "0.6"
+log = "0.4"
 memoffset = "0.9"
 minidump-common = "0.21"
 scroll = "0.12"
@@ -29,6 +30,7 @@ nix = { version = "0.27", default-features = false, features = [
     "mman",
     "process",
     "ptrace",
+    "signal",
     "user",
 ] }
 # Used for parsing procfs info.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ goblin = "0.8"
 memmap2 = "0.9"
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
-nix = { version = "0.27", default-features = false, features = [
+nix = { version = "0.28", default-features = false, features = [
     "mman",
     "process",
     "ptrace",

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -13,10 +13,9 @@ mod linux {
         LINUX_GATE_LIBRARY_NAME,
     };
     use nix::{
-        sys::mman::{mmap, MapFlags, ProtFlags},
+        sys::mman::{mmap_anonymous, MapFlags, ProtFlags},
         unistd::getppid,
     };
-    use std::os::fd::BorrowedFd;
 
     macro_rules! test {
         ($x:expr, $errmsg:expr) => {
@@ -216,18 +215,16 @@ mod linux {
         let memory_size = std::num::NonZeroUsize::new(page_size.unwrap() as usize).unwrap();
         // Get some memory to be mapped by the child-process
         let mapped_mem = unsafe {
-            mmap::<BorrowedFd>(
+            mmap_anonymous(
                 None,
                 memory_size,
                 ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
                 MapFlags::MAP_PRIVATE | MapFlags::MAP_ANON,
-                None,
-                0,
             )
             .unwrap()
         };
 
-        println!("{} {}", mapped_mem as usize, memory_size);
+        println!("{} {}", mapped_mem.as_ptr() as usize, memory_size);
         loop {
             std::thread::park();
         }

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -8,6 +8,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 mod linux {
     use super::*;
     use minidump_writer::{
+        minidump_writer::STOP_TIMEOUT,
         ptrace_dumper::{PtraceDumper, AT_SYSINFO_EHDR},
         LINUX_GATE_LIBRARY_NAME,
     };
@@ -29,13 +30,13 @@ mod linux {
 
     fn test_setup() -> Result<()> {
         let ppid = getppid();
-        PtraceDumper::new(ppid.as_raw())?;
+        PtraceDumper::new(ppid.as_raw(), STOP_TIMEOUT)?;
         Ok(())
     }
 
     fn test_thread_list() -> Result<()> {
         let ppid = getppid();
-        let dumper = PtraceDumper::new(ppid.as_raw())?;
+        let dumper = PtraceDumper::new(ppid.as_raw(), STOP_TIMEOUT)?;
         test!(!dumper.threads.is_empty(), "No threads")?;
         test!(
             dumper
@@ -51,7 +52,7 @@ mod linux {
 
     fn test_copy_from_process(stack_var: usize, heap_var: usize) -> Result<()> {
         let ppid = getppid().as_raw();
-        let mut dumper = PtraceDumper::new(ppid)?;
+        let mut dumper = PtraceDumper::new(ppid, STOP_TIMEOUT)?;
         dumper.suspend_threads()?;
         let stack_res = PtraceDumper::copy_from_process(ppid, stack_var as *mut libc::c_void, 1)?;
 
@@ -73,7 +74,7 @@ mod linux {
 
     fn test_find_mappings(addr1: usize, addr2: usize) -> Result<()> {
         let ppid = getppid();
-        let dumper = PtraceDumper::new(ppid.as_raw())?;
+        let dumper = PtraceDumper::new(ppid.as_raw(), STOP_TIMEOUT)?;
         dumper
             .find_mapping(addr1)
             .ok_or("No mapping for addr1 found")?;
@@ -90,7 +91,7 @@ mod linux {
         let ppid = getppid().as_raw();
         let exe_link = format!("/proc/{}/exe", ppid);
         let exe_name = std::fs::read_link(exe_link)?.into_os_string();
-        let mut dumper = PtraceDumper::new(getppid().as_raw())?;
+        let mut dumper = PtraceDumper::new(getppid().as_raw(), STOP_TIMEOUT)?;
         let mut found_exe = None;
         for (idx, mapping) in dumper.mappings.iter().enumerate() {
             if mapping.name.as_ref().map(|x| x.into()).as_ref() == Some(&exe_name) {
@@ -107,7 +108,7 @@ mod linux {
 
     fn test_merged_mappings(path: String, mapped_mem: usize, mem_size: usize) -> Result<()> {
         // Now check that PtraceDumper interpreted the mappings properly.
-        let dumper = PtraceDumper::new(getppid().as_raw())?;
+        let dumper = PtraceDumper::new(getppid().as_raw(), STOP_TIMEOUT)?;
         let mut mapping_count = 0;
         for map in &dumper.mappings {
             if map
@@ -129,7 +130,7 @@ mod linux {
 
     fn test_linux_gate_mapping_id() -> Result<()> {
         let ppid = getppid().as_raw();
-        let mut dumper = PtraceDumper::new(ppid)?;
+        let mut dumper = PtraceDumper::new(ppid, STOP_TIMEOUT)?;
         let mut found_linux_gate = false;
         for mut mapping in dumper.mappings.clone() {
             if mapping.name == Some(LINUX_GATE_LIBRARY_NAME.into()) {
@@ -148,7 +149,7 @@ mod linux {
 
     fn test_mappings_include_linux_gate() -> Result<()> {
         let ppid = getppid().as_raw();
-        let dumper = PtraceDumper::new(ppid)?;
+        let dumper = PtraceDumper::new(ppid, STOP_TIMEOUT)?;
         let linux_gate_loc = dumper.auxv[&AT_SYSINFO_EHDR];
         test!(linux_gate_loc != 0, "linux_gate_loc == 0")?;
         let mut found_linux_gate = false;

--- a/src/mac/mach.rs
+++ b/src/mac/mach.rs
@@ -590,7 +590,8 @@ pub fn sysctl_by_name<T: Sized + Default>(name: &[u8]) -> T {
             0,
         ) != 0
         {
-            // log?
+            // TODO convert to ascii characters when logging?
+            log::warn!("failed to get sysctl for {name:?}");
             T::default()
         } else {
             out

--- a/src/mac/streams/exception.rs
+++ b/src/mac/streams/exception.rs
@@ -70,7 +70,7 @@ impl MinidumpWriter {
                         // For all other exceptions types, the value in the code
                         // _should_ never exceed 32 bits, crashpad does an actual
                         // range check here.
-                        if code > u32::MAX {
+                        if code > u32::MAX.into() {
                             // TODO: do something more than logging?
                             log::warn!("exception code {code:#018x} exceeds the expected 32 bits");
                         }

--- a/src/mac/streams/exception.rs
+++ b/src/mac/streams/exception.rs
@@ -69,9 +69,11 @@ impl MinidumpWriter {
                     } else {
                         // For all other exceptions types, the value in the code
                         // _should_ never exceed 32 bits, crashpad does an actual
-                        // range check here, but since we don't really log anything
-                        // else at the moment I'll punt that for now
-                        // TODO: log/do something if exc.code > u32::MAX
+                        // range check here.
+                        if code > u32::MAX {
+                            // TODO: do something more than logging?
+                            log::warn!("exception code {code:#018x} exceeds the expected 32 bits");
+                        }
                         code as u32
                     };
 

--- a/src/mac/streams/thread_names.rs
+++ b/src/mac/streams/thread_names.rs
@@ -25,8 +25,8 @@ impl MinidumpWriter {
             // not a critical failure
             let name_loc = match Self::write_thread_name(buffer, dumper, tid) {
                 Ok(loc) => loc,
-                Err(_err) => {
-                    // TODO: log error
+                Err(err) => {
+                    log::warn!("failed to write thread name for thread {tid}: {err}");
                     write_string_to_location(buffer, "")?
                 }
             };

--- a/src/windows/minidump_writer.rs
+++ b/src/windows/minidump_writer.rs
@@ -185,13 +185,13 @@ impl MinidumpWriter {
                 // This is a mut pointer for some reason...I don't _think_ it is
                 // actually mut in practice...?
                 ExceptionPointers: crash_context.exception_pointers as *mut _,
-                /// The `EXCEPTION_POINTERS` contained in crash context is a pointer into the
-                /// memory of the process that crashed, as it contains an `EXCEPTION_RECORD`
-                /// record which is an internally linked list, so in the case that we are
-                /// dumping a process other than the current one, we need to tell
-                /// `MiniDumpWriteDump` that the pointers come from an external process so that
-                /// it can use eg `ReadProcessMemory` to get the contextual information from
-                /// the crash, rather than from the current process
+                // The `EXCEPTION_POINTERS` contained in crash context is a pointer into the
+                // memory of the process that crashed, as it contains an `EXCEPTION_RECORD`
+                // record which is an internally linked list, so in the case that we are
+                // dumping a process other than the current one, we need to tell
+                // `MiniDumpWriteDump` that the pointers come from an external process so that
+                // it can use eg `ReadProcessMemory` to get the contextual information from
+                // the crash, rather than from the current process
                 ClientPointers: i32::from(is_external_process),
             },
         );

--- a/tests/ptrace_dumper.rs
+++ b/tests/ptrace_dumper.rs
@@ -29,7 +29,8 @@ fn test_thread_list_from_parent() {
     let num_of_threads = 5;
     let mut child = start_child_and_wait_for_threads(num_of_threads);
     let pid = child.id() as i32;
-    let mut dumper = PtraceDumper::new(pid).expect("Couldn't init dumper");
+    let mut dumper = PtraceDumper::new(pid, minidump_writer::minidump_writer::STOP_TIMEOUT)
+        .expect("Couldn't init dumper");
     assert_eq!(dumper.threads.len(), num_of_threads);
     dumper.suspend_threads().expect("Could not suspend threads");
 
@@ -209,7 +210,8 @@ fn test_sanitize_stack_copy() {
     let heap_addr = usize::from_str_radix(output.next().unwrap().trim_start_matches("0x"), 16)
         .expect("unable to parse mmap_addr");
 
-    let mut dumper = PtraceDumper::new(pid).expect("Couldn't init dumper");
+    let mut dumper = PtraceDumper::new(pid, minidump_writer::minidump_writer::STOP_TIMEOUT)
+        .expect("Couldn't init dumper");
     assert_eq!(dumper.threads.len(), num_of_threads);
     dumper.suspend_threads().expect("Could not suspend threads");
     let thread_info = dumper


### PR DESCRIPTION
If this fails, we continue as we used to. This is an attempt to get a consistent/static process state.

Closes #28.

Needs to be tested in all sorts of scenarios (but due to the timeout and the fact that it continues on failure, one would hope it'd only be an improvement).