### PR TITLE
Fix segfault in 1.77.0+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         run: cargo test --target ${{ matrix.job.target }}
       - name: Release test
         if: ${{ matrix.job.release }}
-        run:
+        run: |
           cargo test --target ${{ matrix.job.target }} --release --no-run
           cargo test --target ${{ matrix.job.target }} --release
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         job:
-          - { os: ubuntu-22.04, target: x86_64-unknown-linux-gnu }
+          - { os: ubuntu-22.04, target: x86_64-unknown-linux-gnu, release: true }
           - { os: ubuntu-22.04,  target: x86_64-unknown-linux-musl }
           - { os: windows-2022,  target: x86_64-pc-windows-msvc }
           - { os: macos-13,      target: x86_64-apple-darwin }
@@ -49,6 +49,11 @@ jobs:
         run: cargo test --target ${{ matrix.job.target }} --no-run
       - name: Test
         run: cargo test --target ${{ matrix.job.target }}
+      - name: Release test
+        if: ${{ matrix.job.release }}
+        run:
+          cargo test --target ${{ matrix.job.target }} --release --no-run
+          cargo test --target ${{ matrix.job.target }} --release
 
   install-cross:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This bug was filed on our library wrapping minidump-writer https://github.com/EmbarkStudios/crash-handling/issues/84, but was an issue in this library. Basically, `u128`'s layout was [changed](https://blog.rust-lang.org/2024/03/30/i128-layout-update.html), causing the sse `movaps` instruction to segfault due to misalignment. This just changes the copy function to instead cast both blocks of memory to `u8` slices to avoid alignment altogether, these are after all just blocks of raw bytes.

Resolves: https://github.com/EmbarkStudios/crash-handling/issues/84