### PR TITLE
Add aarch64-android testing to CI

### DIFF
--- a/.cargo/android-runner.sh
+++ b/.cargo/android-runner.sh
@@ -3,7 +3,12 @@
 BINARY=$1
 shift
 
+# When pushing a bin, the full target dir is appended (including the target
+# triple). There's no need for this, so strip it away. This simplifies the
+# `TEST_HELPER` definition across multiple architectures.
+REMOTE_BINARY="/data/local/$(basename $BINARY)"
+
 # Make sure to run the following to copy the test helper binary over.
-# cargo run --target x86_64-linux-android --bin test
-adb push "$BINARY" "/data/local/$BINARY"
-adb shell "chmod 777 /data/local/$BINARY && env TEST_HELPER=/data/local/target/x86_64-linux-android/debug/test /data/local/$BINARY" "$@"
+# cargo run --target ANDROID-TARGET --bin test
+adb push $BINARY $REMOTE_BINARY
+adb shell "chmod 777 $REMOTE_BINARY && env TEST_HELPER=/data/local/test $REMOTE_BINARY" "$@"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -12,3 +12,7 @@
 [target.x86_64-linux-android]
 linker = "x86_64-linux-android30-clang"
 runner = [".cargo/android-runner.sh"]
+
+[target.aarch64-linux-android]
+linker = "aarch64-linux-android30-clang"
+runner = [".cargo/android-runner.sh"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,16 +107,23 @@ jobs:
   # interacts with this job.
   test-android:
     name: Test android
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.job.on }}
+    strategy:
+      matrix:
+        job:
+          - { target: x86_64-linux-android, arch: x86_64, on: ubuntu-latest }
+          - { target: aarch64-linux-android, arch: arm64-v8a, on: macos-14 }
     env:
-      ANDROID_HOME: /usr/local/lib/android/sdk
+      ANDROID_HOME: ${{ matrix.job.on == 'ubuntu-latest' && '/usr/local/lib/android/sdk' || '/Users/runner/Library/Android/sdk' }}
+      CARGO_BUILD_TARGET: ${{ matrix.job.target }}
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          target: x86_64-linux-android
+          target: ${{ matrix.job.target }}
       - name: Enable KVM
+        if: ${{ matrix.job.on == 'ubuntu-latest' }}
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
@@ -124,19 +131,22 @@ jobs:
       # Add the (eventual) NDK toolchain bin directory to PATH so the linker is
       # available to cargo
       - run: echo "$ANDROID_HOME/ndk/26.2.11394342/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
+        if: ${{ matrix.job.on == 'ubuntu-latest' }}
+      - run: echo "$ANDROID_HOME/ndk/26.2.11394342/toolchains/llvm/prebuilt/macos-aarch64/bin" >> $GITHUB_PATH
+        if: ${{ matrix.job.on == 'macos-14' }}
       - name: Build/run tests in android emulator
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          arch: x86_64
+          arch: ${{ matrix.job.arch }}
           api-level: 30
           ndk: 26.2.11394342
           script: |
             # run adb as root so we can create remote directories
             adb root
             # Copy test helper binary over as a side-effect of running it.
-            cargo run --target x86_64-linux-android --bin test -- nop
+            cargo run --bin test -- nop
             # Build and run tests
-            cargo test --target x86_64-linux-android
+            cargo test
 
   deny-check:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Let's see if this works... I didn't try locally testing aarch64-android because I didn't want to jump through hoops to install the aarch64 qemu and get that working (Google dropped support so it doesn't Just Work).