### PR TITLE
Support faster methods of reading process memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Changed
+- [PR#118](https://github.com/rust-minidump/minidump-writer/pull/118) resolved [#72](https://github.com/rust-minidump/minidump-writer/issues/72) by adding support for reading process memory via `process_vm_readv` and `/proc/{pid}/mem`, in addition to the original `PTRACE_PEEKDATA`. This gives significant performance benefits as memory can now be read in blocks of arbitrary size instead of word-by-word with ptrace.
+
 ## [0.9.0] - 2024-07-20
 ### Fixed
 - [PR#117](https://github.com/rust-minidump/minidump-writer/pull/117) resolved [#79](https://github.com/rust-minidump/minidump-writer/issues/79) by enabling reading of a module's build id and soname directly from the mapped process rather than relying on file reading, though that is still used as a fallback.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ nix = { version = "0.28", default-features = false, features = [
     "process",
     "ptrace",
     "signal",
+    "uio",
     "user",
 ] }
 # Used for parsing procfs info.

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -139,7 +139,7 @@ mod linux {
                 found_linux_gate = true;
                 dumper.suspend_threads()?;
                 let module_reader::BuildId(id) =
-                    dumper.from_process_memory_for_mapping(&mapping)?;
+                    PtraceDumper::from_process_memory_for_mapping(&mapping, ppid)?;
                 test!(!id.is_empty(), "id-vec is empty")?;
                 test!(id.iter().any(|&x| x > 0), "all id elements are 0")?;
                 dumper.resume_threads()?;

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -52,7 +52,8 @@ mod linux {
         let ppid = getppid().as_raw();
         let mut dumper = PtraceDumper::new(ppid, STOP_TIMEOUT, Default::default())?;
         dumper.suspend_threads()?;
-        let stack_res = PtraceDumper::copy_from_process(ppid, stack_var as *mut libc::c_void, 1)?;
+        let stack_res =
+            PtraceDumper::copy_from_process(ppid, stack_var, std::mem::size_of::<usize>())?;
 
         let expected_stack: libc::c_long = 0x11223344;
         test!(
@@ -60,7 +61,8 @@ mod linux {
             "stack var not correct"
         )?;
 
-        let heap_res = PtraceDumper::copy_from_process(ppid, heap_var as *mut libc::c_void, 1)?;
+        let heap_res =
+            PtraceDumper::copy_from_process(ppid, heap_var, std::mem::size_of::<usize>())?;
         let expected_heap: libc::c_long = 0x55667788;
         test!(
             heap_res == expected_heap.to_ne_bytes(),

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -10,6 +10,7 @@ mod dso_debug;
 mod dumper_cpu_info;
 pub mod errors;
 pub mod maps_reader;
+pub mod mem_reader;
 pub mod minidump_writer;
 pub mod module_reader;
 pub mod ptrace_dumper;
@@ -17,3 +18,4 @@ pub(crate) mod sections;
 pub mod thread_info;
 
 pub use maps_reader::LINUX_GATE_LIBRARY_NAME;
+pub type Pid = i32;

--- a/src/linux/auxv/mod.rs
+++ b/src/linux/auxv/mod.rs
@@ -1,6 +1,6 @@
 pub use reader::ProcfsAuxvIter;
 use {
-    crate::linux::thread_info::Pid,
+    crate::Pid,
     std::{fs::File, io::BufReader},
     thiserror::Error,
 };

--- a/src/linux/dso_debug.rs
+++ b/src/linux/dso_debug.rs
@@ -85,11 +85,7 @@ pub fn write_dso_debug_stream(
         .get_program_header_address()
         .ok_or(SectionDsoDebugError::CouldNotFind("AT_PHDR in auxv"))? as usize;
 
-    let ph = PtraceDumper::copy_from_process(
-        blamed_thread,
-        phdr as *mut libc::c_void,
-        SIZEOF_PHDR * phnum_max,
-    )?;
+    let ph = PtraceDumper::copy_from_process(blamed_thread, phdr, SIZEOF_PHDR * phnum_max)?;
     let program_headers;
     #[cfg(target_pointer_width = "64")]
     {
@@ -137,7 +133,7 @@ pub fn write_dso_debug_stream(
     loop {
         let dyn_data = PtraceDumper::copy_from_process(
             blamed_thread,
-            (dyn_addr as usize + dynamic_length) as *mut libc::c_void,
+            dyn_addr as usize + dynamic_length,
             dyn_size,
         )?;
         dynamic_length += dyn_size;
@@ -163,11 +159,8 @@ pub fn write_dso_debug_stream(
     // See <link.h> for a more detailed discussion of the how the dynamic
     // loader communicates with debuggers.
 
-    let debug_entry_data = PtraceDumper::copy_from_process(
-        blamed_thread,
-        r_debug as *mut libc::c_void,
-        std::mem::size_of::<RDebug>(),
-    )?;
+    let debug_entry_data =
+        PtraceDumper::copy_from_process(blamed_thread, r_debug, std::mem::size_of::<RDebug>())?;
 
     // goblin::elf::Dyn doesn't have padding bytes
     let (head, body, _tail) = unsafe { debug_entry_data.align_to::<RDebug>() };
@@ -180,7 +173,7 @@ pub fn write_dso_debug_stream(
     while curr_map != 0 {
         let link_map_data = PtraceDumper::copy_from_process(
             blamed_thread,
-            curr_map as *mut libc::c_void,
+            curr_map,
             std::mem::size_of::<LinkMap>(),
         )?;
 
@@ -204,11 +197,8 @@ pub fn write_dso_debug_stream(
         for (idx, map) in dso_vec.iter().enumerate() {
             let mut filename = String::new();
             if map.l_name > 0 {
-                let filename_data = PtraceDumper::copy_from_process(
-                    blamed_thread,
-                    map.l_name as *mut libc::c_void,
-                    256,
-                )?;
+                let filename_data =
+                    PtraceDumper::copy_from_process(blamed_thread, map.l_name, 256)?;
 
                 // C - string is NULL-terminated
                 if let Some(name) = filename_data.splitn(2, |x| *x == b'\0').next() {
@@ -243,11 +233,8 @@ pub fn write_dso_debug_stream(
     };
 
     dirent.location.data_size += dynamic_length as u32;
-    let dso_debug_data = PtraceDumper::copy_from_process(
-        blamed_thread,
-        dyn_addr as *mut libc::c_void,
-        dynamic_length,
-    )?;
+    let dso_debug_data =
+        PtraceDumper::copy_from_process(blamed_thread, dyn_addr as usize, dynamic_length)?;
     MemoryArrayWriter::write_bytes(buffer, &dso_debug_data);
 
     Ok(dirent)

--- a/src/linux/errors.rs
+++ b/src/linux/errors.rs
@@ -1,8 +1,6 @@
-use crate::auxv::AuxvError;
-use crate::dir_section::FileWriterError;
-use crate::maps_reader::MappingInfo;
-use crate::mem_writer::MemoryWriterError;
-use crate::thread_info::Pid;
+use crate::{
+    dir_section::FileWriterError, maps_reader::MappingInfo, mem_writer::MemoryWriterError, Pid,
+};
 use goblin;
 use nix::errno::Errno;
 use std::ffi::OsString;
@@ -87,6 +85,16 @@ pub enum AndroidError {
 }
 
 #[derive(Debug, Error)]
+#[error("Copy from process {child} failed (source {src}, offset: {offset}, length: {length})")]
+pub struct CopyFromProcessError {
+    pub child: Pid,
+    pub src: usize,
+    pub offset: usize,
+    pub length: usize,
+    pub source: nix::Error,
+}
+
+#[derive(Debug, Error)]
 pub enum DumperError {
     #[error("Failed to get PAGE_SIZE from system")]
     SysConfError(#[from] nix::Error),
@@ -96,8 +104,8 @@ pub enum DumperError {
     PtraceAttachError(Pid, #[source] nix::Error),
     #[error("nix::ptrace::detach(Pid={0}) failed")]
     PtraceDetachError(Pid, #[source] nix::Error),
-    #[error("Copy from process {0} failed (source {1}, offset: {2}, length: {3})")]
-    CopyFromProcessError(Pid, usize, usize, usize, #[source] nix::Error),
+    #[error(transparent)]
+    CopyFromProcessError(#[from] CopyFromProcessError),
     #[error("Skipped thread {0} due to it being part of the seccomp sandbox's trusted code")]
     DetachSkippedThread(Pid),
     #[error("No threads left to suspend out of {0}")]
@@ -249,7 +257,7 @@ pub enum ModuleReaderError {
         offset: u64,
         length: u64,
         #[source]
-        error: std::io::Error,
+        error: nix::Error,
     },
     #[error("failed to parse ELF memory: {0}")]
     Parsing(#[from] goblin::error::Error),

--- a/src/linux/errors.rs
+++ b/src/linux/errors.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 pub enum InitError {
     #[error("failed to read auxv")]
-    ReadAuxvFailed(AuxvError),
+    ReadAuxvFailed(crate::auxv::AuxvError),
     #[error("IO error for file {0}")]
     IOError(String, #[source] std::io::Error),
     #[error("crash thread does not reference principal mapping")]
@@ -18,6 +18,8 @@ pub enum InitError {
     AndroidLateInitError(#[from] AndroidError),
     #[error("Failed to read the page size")]
     PageSizeError(#[from] Errno),
+    #[error("Ptrace does not function within the same process")]
+    CannotPtraceSameProcess,
 }
 
 #[derive(Error, Debug)]

--- a/src/linux/maps_reader.rs
+++ b/src/linux/maps_reader.rs
@@ -259,7 +259,7 @@ impl MappingInfo {
         use super::module_reader::{ReadFromModule, SoName};
 
         let mapped_file = MappingInfo::get_mmap(&self.name, self.offset)?;
-        Ok(SoName::read_from_module(&*mapped_file)
+        Ok(SoName::read_from_module((&*mapped_file).into())
             .map_err(|e| MapsReaderError::NoSoName(self.name.clone().unwrap_or_default(), e))?
             .0
             .to_string())

--- a/src/linux/mem_reader.rs
+++ b/src/linux/mem_reader.rs
@@ -1,0 +1,203 @@
+//! Functionality for reading a remote process's memory
+
+use crate::{errors::CopyFromProcessError, ptrace_dumper::PtraceDumper, Pid};
+
+enum Style {
+    /// Uses [`process_vm_readv`](https://linux.die.net/man/2/process_vm_readv)
+    /// to read the memory.
+    ///
+    /// This is not available on old <3.2 (really, ancient) kernels, and requires
+    /// the same permissions as ptrace
+    VirtualMem,
+    /// Reads the memory from `/proc/<pid>/mem`
+    ///
+    /// Available on basically all versions of Linux, but could fail if the process
+    /// has insufficient priveleges, ie ptrace
+    File(std::fs::File),
+    /// Reads the memory with [ptrace (`PTRACE_PEEKDATA`)](https://man7.org/linux/man-pages/man2/ptrace.2.html)
+    ///
+    /// Reads data one word at a time, so slow, but fairly reliable, as long as
+    /// the process can be ptraced
+    Ptrace,
+    /// No methods succeeded, generally there isn't a case where failing a syscall
+    /// will work if called again
+    Unavailable {
+        vmem: nix::Error,
+        file: nix::Error,
+        ptrace: nix::Error,
+    },
+}
+
+pub struct MemReader {
+    /// The pid of the child to read
+    pid: nix::unistd::Pid,
+    style: Option<Style>,
+}
+
+impl std::fmt::Debug for MemReader {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match &self.style {
+            Some(Style::VirtualMem) => "process_vm_readv",
+            Some(Style::File(_)) => "/proc/<pid>/mem",
+            Some(Style::Ptrace) => "PTRACE_PEEKDATA",
+            Some(Style::Unavailable { vmem, file, ptrace }) => {
+                return write!(
+                    f,
+                    "process_vm_readv: {vmem}, /proc/<pid>/mem: {file}, PTRACE_PEEKDATA: {ptrace}"
+                );
+            }
+            None => "unknown",
+        };
+
+        f.write_str(s)
+    }
+}
+
+impl MemReader {
+    #[inline]
+    pub fn new(pid: i32) -> Self {
+        Self {
+            pid: nix::unistd::Pid::from_raw(pid),
+            style: None,
+        }
+    }
+
+    #[inline]
+    pub fn read_to_vec(
+        &mut self,
+        src: usize,
+        length: usize,
+    ) -> Result<Vec<u8>, CopyFromProcessError> {
+        let mut output = vec![0; length];
+        let len = self.read(src, &mut output)?;
+        output.truncate(len);
+        Ok(output)
+    }
+
+    pub fn read(&mut self, src: usize, dst: &mut [u8]) -> Result<usize, CopyFromProcessError> {
+        if let Some(rs) = &mut self.style {
+            let res = match rs {
+                Style::VirtualMem => Self::vmem(self.pid, src, dst).map_err(|s| (s, 0)),
+                Style::File(file) => Self::file(file, src, dst).map_err(|s| (s, 0)),
+                Style::Ptrace => Self::ptrace(self.pid, src, dst),
+                Style::Unavailable { ptrace, .. } => Err((*ptrace, 0)),
+            };
+
+            return res.map_err(|(source, offset)| CopyFromProcessError {
+                child: self.pid.as_raw(),
+                src,
+                offset,
+                length: dst.len(),
+                source,
+            });
+        }
+
+        // Attempt to read in order of speed
+        let vmem = match Self::vmem(self.pid, src, dst) {
+            Ok(len) => {
+                self.style = Some(Style::VirtualMem);
+                return Ok(len);
+            }
+            Err(err) => err,
+        };
+
+        let file = match std::fs::File::open(format!("/proc/{}/mem", self.pid)) {
+            Ok(mut file) => match Self::file(&mut file, src, dst) {
+                Ok(len) => {
+                    self.style = Some(Style::File(file));
+                    return Ok(len);
+                }
+                Err(err) => err,
+            },
+            Err(err) => nix::Error::from_raw(err.raw_os_error().expect(
+                "failed to open /proc/<pid>/mem and the I/O error doesn't have an OS code",
+            )),
+        };
+
+        let ptrace = match Self::ptrace(self.pid, src, dst) {
+            Ok(len) => {
+                self.style = Some(Style::Ptrace);
+                return Ok(len);
+            }
+            Err((err, _)) => err,
+        };
+
+        self.style = Some(Style::Unavailable { vmem, file, ptrace });
+        Err(CopyFromProcessError {
+            child: self.pid.as_raw(),
+            src,
+            offset: 0,
+            length: dst.len(),
+            source: ptrace,
+        })
+    }
+
+    #[inline]
+    fn vmem(pid: nix::unistd::Pid, src: usize, dst: &mut [u8]) -> Result<usize, nix::Error> {
+        let remote = &[nix::sys::uio::RemoteIoVec {
+            base: src,
+            len: dst.len(),
+        }];
+        dbg!(nix::sys::uio::process_vm_readv(
+            pid,
+            &mut [std::io::IoSliceMut::new(dst)],
+            remote
+        ))
+    }
+
+    #[inline]
+    fn file(file: &mut std::fs::File, src: usize, dst: &mut [u8]) -> Result<usize, nix::Error> {
+        use std::os::unix::fs::FileExt;
+
+        dbg!(file.read_exact_at(dst, src as u64).map_err(|err| {
+            if let Some(os) = err.raw_os_error() {
+                nix::Error::from_raw(os)
+            } else {
+                nix::Error::E2BIG /* EOF */
+            }
+        }))?;
+
+        Ok(dst.len())
+    }
+
+    #[inline]
+    fn ptrace(
+        pid: nix::unistd::Pid,
+        src: usize,
+        dst: &mut [u8],
+    ) -> Result<usize, (nix::Error, usize)> {
+        let mut offset = 0;
+        let mut chunks = dst.chunks_exact_mut(std::mem::size_of::<usize>());
+
+        while let Some(chunk) = chunks.next() {
+            let word = nix::sys::ptrace::read(pid, (src + offset) as *mut std::ffi::c_void)
+                .map_err(|err| (err, offset))?;
+            chunk.copy_from_slice(&word.to_ne_bytes());
+            offset += std::mem::size_of::<usize>();
+        }
+
+        // I don't think there would ever be a case where we would not read on word boundaries, but just in case...
+        let last = chunks.into_remainder();
+        if last.len() > 0 {
+            let word = nix::sys::ptrace::read(pid, (src + offset) as *mut std::ffi::c_void)
+                .map_err(|err| (err, offset))?;
+            last.copy_from_slice(&word.to_ne_bytes()[..last.len()]);
+        }
+
+        Ok(dst.len())
+    }
+}
+
+impl PtraceDumper {
+    /// Copies a block of bytes from the target process, returning the heap
+    /// allocated copy
+    #[inline]
+    pub fn copy_from_process(
+        pid: Pid,
+        src: usize,
+        length: usize,
+    ) -> Result<Vec<u8>, crate::errors::DumperError> {
+        let mut mem = MemReader::new(pid);
+        Ok(mem.read_to_vec(src, length)?)
+    }
+}

--- a/src/linux/mem_reader.rs
+++ b/src/linux/mem_reader.rs
@@ -138,24 +138,20 @@ impl MemReader {
             base: src,
             len: dst.len(),
         }];
-        dbg!(nix::sys::uio::process_vm_readv(
-            pid,
-            &mut [std::io::IoSliceMut::new(dst)],
-            remote
-        ))
+        nix::sys::uio::process_vm_readv(pid, &mut [std::io::IoSliceMut::new(dst)], remote)
     }
 
     #[inline]
     fn file(file: &mut std::fs::File, src: usize, dst: &mut [u8]) -> Result<usize, nix::Error> {
         use std::os::unix::fs::FileExt;
 
-        dbg!(file.read_exact_at(dst, src as u64).map_err(|err| {
+        file.read_exact_at(dst, src as u64).map_err(|err| {
             if let Some(os) = err.raw_os_error() {
                 nix::Error::from_raw(os)
             } else {
                 nix::Error::E2BIG /* EOF */
             }
-        }))?;
+        })?;
 
         Ok(dst.len())
     }

--- a/src/linux/mem_reader.rs
+++ b/src/linux/mem_reader.rs
@@ -12,7 +12,7 @@ enum Style {
     /// Reads the memory from `/proc/<pid>/mem`
     ///
     /// Available on basically all versions of Linux, but could fail if the process
-    /// has insufficient priveleges, ie ptrace
+    /// has insufficient privileges, ie ptrace
     File(std::fs::File),
     /// Reads the memory with [ptrace (`PTRACE_PEEKDATA`)](https://man7.org/linux/man-pages/man2/ptrace.2.html)
     ///

--- a/src/linux/mem_reader.rs
+++ b/src/linux/mem_reader.rs
@@ -165,7 +165,7 @@ impl MemReader {
         let mut offset = 0;
         let mut chunks = dst.chunks_exact_mut(std::mem::size_of::<usize>());
 
-        while let Some(chunk) = chunks.next() {
+        for chunk in chunks.by_ref() {
             let word = nix::sys::ptrace::read(pid, (src + offset) as *mut std::ffi::c_void)
                 .map_err(|err| (err, offset))?;
             chunk.copy_from_slice(&word.to_ne_bytes());
@@ -174,7 +174,7 @@ impl MemReader {
 
         // I don't think there would ever be a case where we would not read on word boundaries, but just in case...
         let last = chunks.into_remainder();
-        if last.len() > 0 {
+        if !last.is_empty() {
             let word = nix::sys::ptrace::read(pid, (src + offset) as *mut std::ffi::c_void)
                 .map_err(|err| (err, offset))?;
             last.copy_from_slice(&word.to_ne_bytes()[..last.len()]);

--- a/src/linux/mem_reader.rs
+++ b/src/linux/mem_reader.rs
@@ -54,11 +54,42 @@ impl std::fmt::Debug for MemReader {
 }
 
 impl MemReader {
+    /// Creates a [`Self`] for the specified process id, the method used will
+    /// be probed for on the first access
     #[inline]
     pub fn new(pid: i32) -> Self {
         Self {
             pid: nix::unistd::Pid::from_raw(pid),
             style: None,
+        }
+    }
+
+    #[inline]
+    #[doc(hidden)]
+    pub fn for_virtual_mem(pid: i32) -> Self {
+        Self {
+            pid: nix::unistd::Pid::from_raw(pid),
+            style: Some(Style::VirtualMem),
+        }
+    }
+
+    #[inline]
+    #[doc(hidden)]
+    pub fn for_file(pid: i32) -> std::io::Result<Self> {
+        let file = std::fs::File::open(format!("/proc/{pid}/mem"))?;
+
+        Ok(Self {
+            pid: nix::unistd::Pid::from_raw(pid),
+            style: Some(Style::File(file)),
+        })
+    }
+
+    #[inline]
+    #[doc(hidden)]
+    pub fn for_ptrace(pid: i32) -> Self {
+        Self {
+            pid: nix::unistd::Pid::from_raw(pid),
+            style: Some(Style::Ptrace),
         }
     }
 

--- a/src/linux/minidump_writer.rs
+++ b/src/linux/minidump_writer.rs
@@ -10,10 +10,10 @@ use crate::{
         maps_reader::{MappingInfo, MappingList},
         ptrace_dumper::PtraceDumper,
         sections::*,
-        thread_info::Pid,
     },
     mem_writer::{Buffer, MemoryArrayWriter, MemoryWriter, MemoryWriterError},
     minidump_format::*,
+    Pid,
 };
 use std::{
     io::{Seek, Write},
@@ -206,7 +206,7 @@ impl MinidumpWriter {
 
         let stack_copy = match PtraceDumper::copy_from_process(
             self.blamed_thread,
-            valid_stack_pointer as *mut libc::c_void,
+            valid_stack_pointer,
             stack_len,
         ) {
             Ok(x) => x,

--- a/src/linux/module_reader.rs
+++ b/src/linux/module_reader.rs
@@ -1,71 +1,87 @@
 use crate::errors::ModuleReaderError as Error;
+use crate::mem_reader::MemReader;
 use crate::minidump_format::GUID;
 use goblin::{
     container::{Container, Ctx, Endian},
     elf,
 };
-use std::ffi::CStr;
+use std::{borrow::Cow, ffi::CStr};
+
+type Buf<'buf> = Cow<'buf, [u8]>;
 
 const NOTE_SECTION_NAME: &[u8] = b".note.gnu.build-id\0";
 
-pub trait ModuleMemory {
-    type Memory: std::ops::Deref<Target = [u8]>;
+pub struct ProcessReader {
+    inner: MemReader,
+    start_address: u64,
+}
 
-    /// Read memory from the module.
-    fn read_module_memory(&self, offset: u64, length: u64) -> std::io::Result<Self::Memory>;
-
-    /// The base address of the module in memory, if loaded in the address space of a program.
-    /// The default implementation returns None.
-    fn base_address(&self) -> Option<u64> {
-        None
-    }
-
-    /// Whether the module memory is from a module loaded in the address space of a program.
-    /// The default implementation assumes this to be true if a base address is provided.
-    fn is_loaded_in_program(&self) -> bool {
-        self.base_address().is_some()
+impl ProcessReader {
+    pub fn new(pid: i32, start_address: usize) -> Self {
+        Self {
+            inner: MemReader::new(pid),
+            start_address: start_address as u64,
+        }
     }
 }
 
-impl<'a> ModuleMemory for &'a [u8] {
-    type Memory = Self;
+pub enum ProcessMemory<'buf> {
+    Slice(&'buf [u8]),
+    Process(ProcessReader),
+}
 
-    fn read_module_memory(&self, offset: u64, length: u64) -> std::io::Result<Self::Memory> {
-        self.get(offset as usize..(offset + length) as usize)
-            .ok_or_else(|| {
-                std::io::Error::new(
-                    std::io::ErrorKind::UnexpectedEof,
-                    format!("{} out of bounds", offset + length),
-                )
-            })
+impl<'buf> From<&'buf [u8]> for ProcessMemory<'buf> {
+    fn from(value: &'buf [u8]) -> Self {
+        Self::Slice(value)
     }
 }
 
-/// Indicate that a ModuleMemory implementation is read from the address space of a program with
-/// the given base address.
-pub struct ModuleMemoryAtAddress<T>(pub T, pub u64);
-
-impl<T: ModuleMemory> ModuleMemory for ModuleMemoryAtAddress<T> {
-    type Memory = T::Memory;
-
-    fn read_module_memory(&self, offset: u64, length: u64) -> std::io::Result<Self::Memory> {
-        self.0.read_module_memory(offset, length)
-    }
-
-    fn base_address(&self) -> Option<u64> {
-        Some(self.1)
+impl<'buf> From<ProcessReader> for ProcessMemory<'buf> {
+    fn from(value: ProcessReader) -> Self {
+        Self::Process(value)
     }
 }
 
-fn read<T: ModuleMemory>(mem: &T, offset: u64, length: u64) -> Result<T::Memory, Error> {
-    mem.read_module_memory(offset, length)
-        .map_err(|error| Error::ReadModuleMemory {
-            offset,
-            length,
-            error,
-        })
+impl<'buf> ProcessMemory<'buf> {
+    #[inline]
+    fn read(&mut self, offset: u64, length: u64) -> Result<Buf<'buf>, Error> {
+        match self {
+            Self::Process(pr) => pr
+                .inner
+                .read_to_vec((pr.start_address + offset) as _, length as _)
+                .map(Cow::Owned)
+                .map_err(|err| Error::ReadModuleMemory {
+                    offset,
+                    length,
+                    error: err.source,
+                }),
+            Self::Slice(s) => s
+                .get(offset as usize..(offset + length) as usize)
+                .map(Cow::Borrowed)
+                .ok_or_else(|| Error::ReadModuleMemory {
+                    offset,
+                    length,
+                    error: nix::Error::EACCES,
+                }),
+        }
+    }
+
+    /// Calculates the absolute address of the specified relative address
+    #[inline]
+    fn absolute(&self, addr: u64) -> u64 {
+        let Self::Process(pr) = self else {
+            return addr;
+        };
+        addr.checked_sub(pr.start_address).unwrap_or(addr)
+    }
+
+    #[inline]
+    fn is_process_memory(&self) -> bool {
+        matches!(self, Self::Process(_))
+    }
 }
 
+#[inline]
 fn is_executable_section(header: &elf::SectionHeader) -> bool {
     header.sh_type == elf::section_header::SHT_PROGBITS
         && header.sh_flags & u64::from(elf::section_header::SHF_ALLOC) != 0
@@ -92,12 +108,12 @@ fn build_id_from_bytes(data: &[u8]) -> Vec<u8> {
 }
 
 // `name` should be null-terminated
-fn section_header_with_name<'a>(
-    section_headers: &'a elf::SectionHeaders,
+fn section_header_with_name<'sc>(
+    section_headers: &'sc elf::SectionHeaders,
     strtab_index: usize,
     name: &[u8],
-    module_memory: &impl ModuleMemory,
-) -> Result<Option<&'a elf::SectionHeader>, Error> {
+    module_memory: &mut ProcessMemory<'_>,
+) -> Result<Option<&'sc elf::SectionHeader>, Error> {
     let strtab_section_header = section_headers.get(strtab_index).ok_or(Error::NoStrTab)?;
     for header in section_headers {
         let sh_name = header.sh_name as u64;
@@ -109,11 +125,7 @@ fn section_header_with_name<'a>(
             // This can't be a match.
             continue;
         }
-        let n = read(
-            module_memory,
-            strtab_section_header.sh_offset + sh_name,
-            name.len() as u64,
-        )?;
+        let n = module_memory.read(strtab_section_header.sh_offset + sh_name, name.len() as u64)?;
         if name == &*n {
             return Ok(Some(header));
         }
@@ -123,16 +135,15 @@ fn section_header_with_name<'a>(
 
 /// Types which can be read from an `impl ModuleMemory`.
 pub trait ReadFromModule: Sized {
-    fn read_from_module(module_memory: impl ModuleMemory) -> Result<Self, Error>;
+    fn read_from_module(module_memory: ProcessMemory<'_>) -> Result<Self, Error>;
 }
 
 /// The module build id.
-#[derive(Default, Clone, Debug)]
 pub struct BuildId(pub Vec<u8>);
 
 impl ReadFromModule for BuildId {
-    fn read_from_module(module_memory: impl ModuleMemory) -> Result<Self, Error> {
-        let reader = ModuleReader::new(module_memory)?;
+    fn read_from_module(module_memory: ProcessMemory<'_>) -> Result<Self, Error> {
+        let mut reader = ModuleReader::new(module_memory)?;
         let program_headers = match reader.build_id_from_program_headers() {
             Ok(v) => return Ok(BuildId(v)),
             Err(e) => Box::new(e),
@@ -191,8 +202,8 @@ impl<'a> Iterator for DynIter<'a> {
 pub struct SoName(pub String);
 
 impl ReadFromModule for SoName {
-    fn read_from_module(module_memory: impl ModuleMemory) -> Result<Self, Error> {
-        let reader = ModuleReader::new(module_memory)?;
+    fn read_from_module(module_memory: ProcessMemory<'_>) -> Result<Self, Error> {
+        let mut reader = ModuleReader::new(module_memory)?;
         let program_headers = match reader.soname_from_program_headers() {
             Ok(v) => return Ok(SoName(v)),
             Err(e) => Box::new(e),
@@ -208,22 +219,23 @@ impl ReadFromModule for SoName {
     }
 }
 
-pub struct ModuleReader<T> {
-    module_memory: T,
+pub struct ModuleReader<'buf> {
+    module_memory: ProcessMemory<'buf>,
     header: elf::Header,
     context: Ctx,
 }
 
-impl<T: ModuleMemory> ModuleReader<T> {
-    pub fn new(module_memory: T) -> Result<Self, Error> {
+impl<'buf> ModuleReader<'buf> {
+    pub fn new(mut module_memory: ProcessMemory<'buf>) -> Result<Self, Error> {
         // We could use `Ctx::default()` (which defaults to the native system), however to be extra
         // permissive we'll just use a 64-bit ("Big") context which would result in the largest
         // possible header size.
         let header_size = elf::Header::size(Ctx::new(Container::Big, Endian::default()));
-        let header_data = read(&module_memory, 0, header_size as u64)?;
+        let header_data = module_memory.read(0, header_size as u64)?;
         let header = elf::Elf::parse_header(&header_data)?;
         let context = Ctx::new(header.container()?, header.endianness()?);
-        Ok(ModuleReader {
+
+        Ok(Self {
             module_memory,
             header,
             context,
@@ -231,7 +243,7 @@ impl<T: ModuleMemory> ModuleReader<T> {
     }
 
     /// Read the SONAME using program headers to locate dynamic library information.
-    pub fn soname_from_program_headers(&self) -> Result<String, Error> {
+    pub fn soname_from_program_headers(&mut self) -> Result<String, Error> {
         let program_headers = self.read_program_headers()?;
 
         let dynamic_segment_header = program_headers
@@ -239,12 +251,12 @@ impl<T: ModuleMemory> ModuleReader<T> {
             .find(|h| h.p_type == elf::program_header::PT_DYNAMIC)
             .ok_or(Error::NoDynamicSection)?;
 
-        let dynamic_section: &[u8] = &self.read_segment(dynamic_segment_header)?;
+        let dynamic_section = self.read_segment(dynamic_segment_header)?;
 
         let mut soname_strtab_offset = None;
         let mut strtab_addr = None;
         let mut strtab_size = None;
-        for dyn_ in DynIter::new(dynamic_section, self.context) {
+        for dyn_ in DynIter::new(&dynamic_section, self.context) {
             let dyn_ = dyn_?;
             match dyn_.d_tag {
                 elf::dynamic::DT_SONAME => soname_strtab_offset = Some(dyn_.d_val),
@@ -257,22 +269,15 @@ impl<T: ModuleMemory> ModuleReader<T> {
         match (strtab_addr, strtab_size, soname_strtab_offset) {
             (None, _, _) | (_, None, _) => Err(Error::NoDynStrSection),
             (_, _, None) => Err(Error::NoSoNameEntry),
-            (Some(mut addr), Some(size), Some(offset)) => {
-                if self.module_memory.is_loaded_in_program() {
-                    if let Some(base) = self.module_memory.base_address() {
-                        // If loaded in memory, the address will be altered to be absolute.
-                        if let Some(r) = addr.checked_sub(base) {
-                            addr = r;
-                        }
-                    }
-                }
-                self.read_name_from_strtab(addr, size, offset)
+            (Some(addr), Some(size), Some(offset)) => {
+                // If loaded in memory, the address will be altered to be absolute.
+                self.read_name_from_strtab(self.module_memory.absolute(addr), size, offset)
             }
         }
     }
 
     /// Read the SONAME using section headers to locate dynamic library information.
-    pub fn soname_from_sections(&self) -> Result<String, Error> {
+    pub fn soname_from_sections(&mut self) -> Result<String, Error> {
         let section_headers = self.read_section_headers()?;
 
         let dynamic_section_header = section_headers
@@ -287,18 +292,17 @@ impl<T: ModuleMemory> ModuleReader<T> {
                     &section_headers,
                     self.header.e_shstrndx as usize,
                     b".dynstr\0",
-                    &self.module_memory,
+                    &mut self.module_memory,
                 )?
                 .ok_or(Error::NoDynStrSection)?,
             };
 
-        let dynamic_section: &[u8] = &read(
-            &self.module_memory,
+        let dynamic_section = self.module_memory.read(
             self.section_offset(dynamic_section_header),
             dynamic_section_header.sh_size,
         )?;
 
-        for dyn_ in DynIter::new(dynamic_section, self.context) {
+        for dyn_ in DynIter::new(&dynamic_section, self.context) {
             let dyn_ = dyn_?;
             if dyn_.d_tag == elf::dynamic::DT_SONAME {
                 let name_offset = dyn_.d_val;
@@ -316,7 +320,7 @@ impl<T: ModuleMemory> ModuleReader<T> {
     }
 
     /// Read the build id from a program header note.
-    pub fn build_id_from_program_headers(&self) -> Result<Vec<u8>, Error> {
+    pub fn build_id_from_program_headers(&mut self) -> Result<Vec<u8>, Error> {
         let program_headers = self.read_program_headers()?;
         for header in program_headers {
             if header.p_type != elf::program_header::PT_NOTE {
@@ -332,14 +336,14 @@ impl<T: ModuleMemory> ModuleReader<T> {
     }
 
     /// Read the build id from a notes section.
-    pub fn build_id_from_section(&self) -> Result<Vec<u8>, Error> {
+    pub fn build_id_from_section(&mut self) -> Result<Vec<u8>, Error> {
         let section_headers = self.read_section_headers()?;
 
         let header = section_header_with_name(
             &section_headers,
             self.header.e_shstrndx as usize,
             NOTE_SECTION_NAME,
-            &self.module_memory,
+            &mut self.module_memory,
         )?
         .ok_or(Error::NoSectionNote)?;
 
@@ -351,7 +355,7 @@ impl<T: ModuleMemory> ModuleReader<T> {
     }
 
     /// Generate a build id by hashing the first page of the text section.
-    pub fn build_id_generate_from_text(&self) -> Result<Vec<u8>, Error> {
+    pub fn build_id_generate_from_text(&mut self) -> Result<Vec<u8>, Error> {
         let Some(text_header) = self
             .read_section_headers()?
             .into_iter()
@@ -362,50 +366,47 @@ impl<T: ModuleMemory> ModuleReader<T> {
 
         // Take at most one page of the text section (we assume page size is 4096 bytes).
         let len = std::cmp::min(4096, text_header.sh_size);
-        let text_data = read(&self.module_memory, text_header.sh_offset, len)?;
+        let text_data = self.module_memory.read(text_header.sh_offset, len)?;
         Ok(build_id_from_bytes(&text_data))
     }
 
-    fn read_segment(&self, header: &elf::ProgramHeader) -> Result<T::Memory, Error> {
-        let (offset, size) = if self.module_memory.is_loaded_in_program() {
+    fn read_segment(&mut self, header: &elf::ProgramHeader) -> Result<Buf<'buf>, Error> {
+        let (offset, size) = if self.module_memory.is_process_memory() {
             (header.p_vaddr, header.p_memsz)
         } else {
             (header.p_offset, header.p_filesz)
         };
 
-        read(&self.module_memory, offset, size)
+        self.module_memory.read(offset, size)
     }
 
     fn read_name_from_strtab(
-        &self,
+        &mut self,
         strtab_offset: u64,
         strtab_size: u64,
         name_offset: u64,
     ) -> Result<String, Error> {
-        let name = read(
-            &self.module_memory,
-            strtab_offset + name_offset,
-            strtab_size - name_offset,
-        )?;
+        let name = self
+            .module_memory
+            .read(strtab_offset + name_offset, strtab_size - name_offset)?;
         return CStr::from_bytes_until_nul(&name)
             .map(|s| s.to_string_lossy().into_owned())
             .map_err(|_| Error::StrTabNoNulByte);
     }
 
     fn section_offset(&self, header: &elf::SectionHeader) -> u64 {
-        if self.module_memory.is_loaded_in_program() {
+        if self.module_memory.is_process_memory() {
             header.sh_addr
         } else {
             header.sh_offset
         }
     }
 
-    fn read_program_headers(&self) -> Result<elf::ProgramHeaders, Error> {
+    fn read_program_headers(&mut self) -> Result<elf::ProgramHeaders, Error> {
         if self.header.e_phoff == 0 {
             return Err(Error::NoProgramHeaders);
         }
-        let program_headers_data = read(
-            &self.module_memory,
+        let program_headers_data = self.module_memory.read(
             self.header.e_phoff,
             self.header.e_phentsize as u64 * self.header.e_phnum as u64,
         )?;
@@ -418,23 +419,18 @@ impl<T: ModuleMemory> ModuleReader<T> {
         Ok(program_headers)
     }
 
-    fn read_section_headers(&self) -> Result<elf::SectionHeaders, Error> {
+    fn read_section_headers(&mut self) -> Result<elf::SectionHeaders, Error> {
         if self.header.e_shoff == 0 {
             return Err(Error::NoSections);
         }
 
-        // FIXME Until a version following goblin 0.8.0 is published (with
-        // `SectionHeader::parse_from`), we read one extra byte preceding the sections so that
-        // `SectionHeader::parse` doesn't return immediately due to a 0 offset.
-
-        let section_headers_data = read(
-            &self.module_memory,
-            self.header.e_shoff - 1,
-            self.header.e_shentsize as u64 * self.header.e_shnum as u64 + 1,
+        let section_headers_data = self.module_memory.read(
+            self.header.e_shoff,
+            self.header.e_shentsize as u64 * self.header.e_shnum as u64,
         )?;
-        let section_headers = elf::SectionHeader::parse(
+        let section_headers = elf::SectionHeader::parse_from(
             &section_headers_data,
-            1,
+            0,
             self.header.e_shnum as usize,
             self.context,
         )?;
@@ -442,12 +438,12 @@ impl<T: ModuleMemory> ModuleReader<T> {
     }
 
     fn find_build_id_note(
-        &self,
+        &mut self,
         offset: u64,
         size: u64,
         alignment: u64,
     ) -> Result<Option<Vec<u8>>, Error> {
-        let notes = read(&self.module_memory, offset, size)?;
+        let notes = self.module_memory.read(offset, size)?;
         for note in (elf::note::NoteDataIterator {
             data: &notes,
             // Note that `NoteDataIterator::size` is poorly named, it is actually an end offset. In
@@ -543,7 +539,7 @@ mod test {
 
     #[test]
     fn build_id_program_headers() {
-        let reader = ModuleReader::new(TINY_ELF).unwrap();
+        let mut reader = ModuleReader::new(TINY_ELF.into()).unwrap();
         let id = reader.build_id_from_program_headers().unwrap();
         assert_eq!(
             id,
@@ -553,7 +549,7 @@ mod test {
 
     #[test]
     fn build_id_section() {
-        let reader = ModuleReader::new(TINY_ELF).unwrap();
+        let mut reader = ModuleReader::new(TINY_ELF.into()).unwrap();
         let id = reader.build_id_from_section().unwrap();
         assert_eq!(
             id,
@@ -563,7 +559,7 @@ mod test {
 
     #[test]
     fn build_id_text_hash() {
-        let reader = ModuleReader::new(TINY_ELF).unwrap();
+        let mut reader = ModuleReader::new(TINY_ELF.into()).unwrap();
         let id = reader.build_id_generate_from_text().unwrap();
         assert_eq!(
             id,
@@ -573,14 +569,14 @@ mod test {
 
     #[test]
     fn soname_program_headers() {
-        let reader = ModuleReader::new(TINY_ELF).unwrap();
+        let mut reader = ModuleReader::new(TINY_ELF.into()).unwrap();
         let soname = reader.soname_from_program_headers().unwrap();
         assert_eq!(soname, "libfoo.so.1");
     }
 
     #[test]
     fn soname_section() {
-        let reader = ModuleReader::new(TINY_ELF).unwrap();
+        let mut reader = ModuleReader::new(TINY_ELF.into()).unwrap();
         let soname = reader.soname_from_sections().unwrap();
         assert_eq!(soname, "libfoo.so.1");
     }

--- a/src/linux/ptrace_dumper.rs
+++ b/src/linux/ptrace_dumper.rs
@@ -191,8 +191,7 @@ impl PtraceDumper {
         // If the thread either disappeared before we could attach to it, or if
         // it was part of the seccomp sandbox's trusted code, it is OK to
         // silently drop it from the minidump.
-        self.threads
-            .retain(|x| dbg!(Self::suspend_thread(x.tid)).is_ok());
+        self.threads.retain(|x| Self::suspend_thread(x.tid).is_ok());
 
         if self.threads.is_empty() {
             Err(DumperError::SuspendNoThreadsLeft(threads_count))

--- a/src/linux/sections/app_memory.rs
+++ b/src/linux/sections/app_memory.rs
@@ -8,7 +8,7 @@ pub fn write(
     for app_memory in &config.app_memory {
         let data_copy = PtraceDumper::copy_from_process(
             config.blamed_thread,
-            app_memory.ptr as *mut libc::c_void,
+            app_memory.ptr,
             app_memory.length,
         )?;
 

--- a/src/linux/sections/mappings.rs
+++ b/src/linux/sections/mappings.rs
@@ -26,7 +26,7 @@ pub fn write(
         }
         let BuildId(identifier) = dumper
             .from_process_memory_for_index(map_idx)
-            .unwrap_or_default();
+            .unwrap_or_else(|_| BuildId(Vec::new()));
 
         // If the identifier is all 0, its an uninteresting mapping (bmc#1676109)
         if identifier.is_empty() || identifier.iter().all(|&x| x == 0) {

--- a/src/linux/sections/thread_list_stream.rs
+++ b/src/linux/sections/thread_list_stream.rs
@@ -117,7 +117,7 @@ pub fn write(
 
                 let memory_copy = PtraceDumper::copy_from_process(
                     thread.thread_id as i32,
-                    ip_memory_d.start_of_memory_range as *mut libc::c_void,
+                    ip_memory_d.start_of_memory_range as _,
                     ip_memory_d.memory.data_size as usize,
                 )?;
 
@@ -196,7 +196,7 @@ fn fill_thread_stack(
 
         let mut stack_bytes = PtraceDumper::copy_from_process(
             thread.thread_id.try_into()?,
-            valid_stack_ptr as *mut libc::c_void,
+            valid_stack_ptr,
             stack_len,
         )?;
         let stack_pointer_offset = stack_ptr.saturating_sub(valid_stack_ptr);

--- a/src/linux/thread_info.rs
+++ b/src/linux/thread_info.rs
@@ -1,4 +1,4 @@
-use crate::errors::ThreadInfoError;
+use crate::{errors::ThreadInfoError, Pid};
 use nix::{errno::Errno, sys::ptrace, unistd};
 use std::{
     io::{self, BufRead},
@@ -6,8 +6,6 @@ use std::{
 };
 
 type Result<T> = std::result::Result<T, ThreadInfoError>;
-
-pub type Pid = i32;
 
 cfg_if::cfg_if! {
     if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {

--- a/src/linux/thread_info/aarch64.rs
+++ b/src/linux/thread_info/aarch64.rs
@@ -1,7 +1,8 @@
-use super::{CommonThreadInfo, NT_Elf, Pid};
+use super::{CommonThreadInfo, NT_Elf};
 use crate::{
     errors::ThreadInfoError,
     minidump_cpu::{RawContextCPU, FP_REG_COUNT, GP_REG_COUNT},
+    Pid,
 };
 use nix::sys::ptrace;
 

--- a/src/linux/thread_info/arm.rs
+++ b/src/linux/thread_info/arm.rs
@@ -1,5 +1,5 @@
-use super::{CommonThreadInfo, NT_Elf, Pid};
-use crate::{errors::ThreadInfoError, minidump_cpu::RawContextCPU};
+use super::{CommonThreadInfo, NT_Elf};
+use crate::{errors::ThreadInfoError, minidump_cpu::RawContextCPU, Pid};
 use nix::sys::ptrace;
 
 type Result<T> = std::result::Result<T, ThreadInfoError>;

--- a/src/linux/thread_info/mips.rs
+++ b/src/linux/thread_info/mips.rs
@@ -1,5 +1,4 @@
-use super::Pid;
-use crate::errors::ThreadInfoError;
+use crate::{errors::ThreadInfoError, Pid};
 use libc;
 
 type Result<T> = std::result::Result<T, ThreadInfoError>;

--- a/src/linux/thread_info/x86.rs
+++ b/src/linux/thread_info/x86.rs
@@ -1,5 +1,5 @@
-use super::{CommonThreadInfo, NT_Elf, Pid};
-use crate::{errors::ThreadInfoError, minidump_cpu::RawContextCPU, minidump_format::format};
+use super::{CommonThreadInfo, NT_Elf};
+use crate::{errors::ThreadInfoError, minidump_cpu::RawContextCPU, minidump_format::format, Pid};
 use core::mem::size_of_val;
 #[cfg(all(not(target_os = "android"), target_arch = "x86"))]
 use libc::user_fpxregs_struct;

--- a/tests/linux_minidump_writer.rs
+++ b/tests/linux_minidump_writer.rs
@@ -706,7 +706,7 @@ fn with_deleted_binary() {
     let pid = child.id() as i32;
 
     let BuildId(mut build_id) =
-        BuildId::read_from_module(mem_slice.as_slice()).expect("Failed to get build_id");
+        BuildId::read_from_module(mem_slice.as_slice().into()).expect("Failed to get build_id");
 
     std::fs::remove_file(&binary_copy).expect("Failed to remove binary");
 

--- a/tests/linux_minidump_writer.rs
+++ b/tests/linux_minidump_writer.rs
@@ -518,13 +518,13 @@ contextual_test! {
         let dump = Minidump::read_path(tmpfile.path()).expect("Failed to read minidump");
         let fds: MinidumpHandleDataStream = dump.get_stream().expect("Couldn't find MinidumpHandleDataStream");
         // We check that we create num_of_files plus stdin, stdout and stderr
-        for i in 0..2 {
+        for i in 0..3 {
             let descriptor = fds.handles.get(i).expect("Descriptor should be present");
             let fd = *descriptor.raw.handle().expect("Handle should be populated");
             assert_eq!(fd, i as u64);
         }
 
-        for i in 3..num_of_files {
+        for i in 3..3 + num_of_files {
             let descriptor = fds.handles.get(i).expect("Descriptor should be present");
             let object_name = descriptor.object_name.as_ref().expect("The path should be populated");
             let file_name = object_name.split('/').last().expect("The filename should be present");

--- a/tests/linux_minidump_writer.rs
+++ b/tests/linux_minidump_writer.rs
@@ -11,7 +11,7 @@ use minidump_writer::{
     minidump_writer::MinidumpWriter,
     module_reader::{BuildId, ReadFromModule},
     ptrace_dumper::PtraceDumper,
-    thread_info::Pid,
+    Pid,
 };
 use nix::{errno::Errno, sys::signal::Signal};
 use procfs_core::process::MMPermissions;
@@ -697,7 +697,7 @@ fn with_deleted_binary() {
     let mut child = Command::new(&binary_copy)
         .env("RUST_BACKTRACE", "1")
         .arg("spawn_and_wait")
-        .arg(format!("{}", num_of_threads))
+        .arg(num_of_threads.to_string())
         .stdout(Stdio::piped())
         .spawn()
         .expect("failed to execute child");


### PR DESCRIPTION
This adds 2 new methods for reading external process memory, in addition to the existing `PTRACE_PEEKDATA` approach currently used.

1. [`process_vm_readv`](https://linux.die.net/man/2/process_vm_readv) - Reads contiguous blocks of a specified size, available since Linux 3.2, so realistically available in every reasonable environment...
2. `/proc/{pid}/mem` - As a fallback in case running in an _ancient_ Linux, we can read from this procfs file, which also allows easy reading of blocks of memory.
3. `PTRACE_PEEKDATA` - The reliable but extremely slow fallback

These 3 methods are probed in the order above until one succeeds, as they all require the same permissions.

Resolves: #72 