### PR TITLE
Setup infrastructure to allow Auxv information to be passed from crashed process.

### DIFF
--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -8,9 +8,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 mod linux {
     use super::*;
     use minidump_writer::{
-        minidump_writer::STOP_TIMEOUT,
-        module_reader,
-        ptrace_dumper::{PtraceDumper, AT_SYSINFO_EHDR},
+        minidump_writer::STOP_TIMEOUT, module_reader, ptrace_dumper::PtraceDumper,
         LINUX_GATE_LIBRARY_NAME,
     };
     use nix::{
@@ -153,7 +151,7 @@ mod linux {
     fn test_mappings_include_linux_gate() -> Result<()> {
         let ppid = getppid().as_raw();
         let dumper = PtraceDumper::new(ppid, STOP_TIMEOUT)?;
-        let linux_gate_loc = dumper.auxv[&AT_SYSINFO_EHDR];
+        let linux_gate_loc = dumper.auxv.get_linux_gate_address().unwrap();
         test!(linux_gate_loc != 0, "linux_gate_loc == 0")?;
         let mut found_linux_gate = false;
         for mapping in &dumper.mappings {

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -28,13 +28,13 @@ mod linux {
 
     fn test_setup() -> Result<()> {
         let ppid = getppid();
-        PtraceDumper::new(ppid.as_raw(), STOP_TIMEOUT)?;
+        PtraceDumper::new(ppid.as_raw(), STOP_TIMEOUT, Default::default())?;
         Ok(())
     }
 
     fn test_thread_list() -> Result<()> {
         let ppid = getppid();
-        let dumper = PtraceDumper::new(ppid.as_raw(), STOP_TIMEOUT)?;
+        let dumper = PtraceDumper::new(ppid.as_raw(), STOP_TIMEOUT, Default::default())?;
         test!(!dumper.threads.is_empty(), "No threads")?;
         test!(
             dumper
@@ -50,7 +50,7 @@ mod linux {
 
     fn test_copy_from_process(stack_var: usize, heap_var: usize) -> Result<()> {
         let ppid = getppid().as_raw();
-        let mut dumper = PtraceDumper::new(ppid, STOP_TIMEOUT)?;
+        let mut dumper = PtraceDumper::new(ppid, STOP_TIMEOUT, Default::default())?;
         dumper.suspend_threads()?;
         let stack_res = PtraceDumper::copy_from_process(ppid, stack_var as *mut libc::c_void, 1)?;
 
@@ -72,7 +72,7 @@ mod linux {
 
     fn test_find_mappings(addr1: usize, addr2: usize) -> Result<()> {
         let ppid = getppid();
-        let dumper = PtraceDumper::new(ppid.as_raw(), STOP_TIMEOUT)?;
+        let dumper = PtraceDumper::new(ppid.as_raw(), STOP_TIMEOUT, Default::default())?;
         dumper
             .find_mapping(addr1)
             .ok_or("No mapping for addr1 found")?;
@@ -89,7 +89,7 @@ mod linux {
         let ppid = getppid().as_raw();
         let exe_link = format!("/proc/{}/exe", ppid);
         let exe_name = std::fs::read_link(exe_link)?.into_os_string();
-        let mut dumper = PtraceDumper::new(ppid, STOP_TIMEOUT)?;
+        let mut dumper = PtraceDumper::new(ppid, STOP_TIMEOUT, Default::default())?;
         dumper.suspend_threads()?;
         let mut found_exe = None;
         for (idx, mapping) in dumper.mappings.iter().enumerate() {
@@ -108,7 +108,7 @@ mod linux {
 
     fn test_merged_mappings(path: String, mapped_mem: usize, mem_size: usize) -> Result<()> {
         // Now check that PtraceDumper interpreted the mappings properly.
-        let dumper = PtraceDumper::new(getppid().as_raw(), STOP_TIMEOUT)?;
+        let dumper = PtraceDumper::new(getppid().as_raw(), STOP_TIMEOUT, Default::default())?;
         let mut mapping_count = 0;
         for map in &dumper.mappings {
             if map
@@ -130,7 +130,7 @@ mod linux {
 
     fn test_linux_gate_mapping_id() -> Result<()> {
         let ppid = getppid().as_raw();
-        let mut dumper = PtraceDumper::new(ppid, STOP_TIMEOUT)?;
+        let mut dumper = PtraceDumper::new(ppid, STOP_TIMEOUT, Default::default())?;
         let mut found_linux_gate = false;
         for mapping in dumper.mappings.clone() {
             if mapping.name == Some(LINUX_GATE_LIBRARY_NAME.into()) {
@@ -150,7 +150,7 @@ mod linux {
 
     fn test_mappings_include_linux_gate() -> Result<()> {
         let ppid = getppid().as_raw();
-        let dumper = PtraceDumper::new(ppid, STOP_TIMEOUT)?;
+        let dumper = PtraceDumper::new(ppid, STOP_TIMEOUT, Default::default())?;
         let linux_gate_loc = dumper.auxv.get_linux_gate_address().unwrap();
         test!(linux_gate_loc != 0, "linux_gate_loc == 0")?;
         let mut found_linux_gate = false;

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -4,7 +4,7 @@
 #[cfg(target_os = "android")]
 mod android;
 pub mod app_memory;
-pub(crate) mod auxv_reader;
+pub(crate) mod auxv;
 pub mod crash_context;
 mod dso_debug;
 mod dumper_cpu_info;

--- a/src/linux/auxv/mod.rs
+++ b/src/linux/auxv/mod.rs
@@ -14,20 +14,14 @@ pub type AuxvType = u32;
 #[cfg(target_pointer_width = "64")]
 pub type AuxvType = u64;
 
-#[cfg(any(target_arch = "arm", all(target_os = "android", target_arch = "x86")))]
-mod consts {
-    use super::AuxvType;
-    pub const AT_PHDR: AuxvType = 3;
-    pub const AT_PHNUM: AuxvType = 5;
-    pub const AT_ENTRY: AuxvType = 9;
-    pub const AT_SYSINFO_EHDR: AuxvType = 33;
-}
-#[cfg(not(any(target_arch = "arm", all(target_os = "android", target_arch = "x86"))))]
 mod consts {
     use super::AuxvType;
     pub const AT_PHDR: AuxvType = libc::AT_PHDR;
     pub const AT_PHNUM: AuxvType = libc::AT_PHNUM;
     pub const AT_ENTRY: AuxvType = libc::AT_ENTRY;
+    #[cfg(target_os = "android")]
+    pub const AT_SYSINFO_EHDR: AuxvType = 33;
+    #[cfg(not(target_os = "android"))]
     pub const AT_SYSINFO_EHDR: AuxvType = libc::AT_SYSINFO_EHDR;
 }
 

--- a/src/linux/auxv/mod.rs
+++ b/src/linux/auxv/mod.rs
@@ -14,14 +14,20 @@ pub type AuxvType = u32;
 #[cfg(target_pointer_width = "64")]
 pub type AuxvType = u64;
 
+#[cfg(target_os = "android")]
+mod consts {
+    use super::AuxvType;
+    pub const AT_PHDR: AuxvType = 3;
+    pub const AT_PHNUM: AuxvType = 5;
+    pub const AT_ENTRY: AuxvType = 9;
+    pub const AT_SYSINFO_EHDR: AuxvType = 33;
+}
+#[cfg(not(target_os = "android"))]
 mod consts {
     use super::AuxvType;
     pub const AT_PHDR: AuxvType = libc::AT_PHDR;
     pub const AT_PHNUM: AuxvType = libc::AT_PHNUM;
     pub const AT_ENTRY: AuxvType = libc::AT_ENTRY;
-    #[cfg(target_os = "android")]
-    pub const AT_SYSINFO_EHDR: AuxvType = 33;
-    #[cfg(not(target_os = "android"))]
     pub const AT_SYSINFO_EHDR: AuxvType = libc::AT_SYSINFO_EHDR;
 }
 

--- a/src/linux/auxv/mod.rs
+++ b/src/linux/auxv/mod.rs
@@ -1,0 +1,48 @@
+pub use reader::ProcfsAuxvIter;
+use {
+    crate::linux::thread_info::Pid,
+    std::{collections::HashMap, fs::File, io::BufReader},
+    thiserror::Error,
+};
+
+mod reader;
+
+/// The type used in auxv keys and values.
+#[cfg(target_pointer_width = "32")]
+pub type AuxvType = u32;
+/// The type used in auxv keys and values.
+#[cfg(target_pointer_width = "64")]
+pub type AuxvType = u64;
+
+/// An auxv key-value pair.
+#[derive(Debug, PartialEq, Eq)]
+pub struct AuxvPair {
+    pub key: AuxvType,
+    pub value: AuxvType,
+}
+
+pub fn read_auxv(pid: Pid) -> Result<HashMap<AuxvType, AuxvType>, AuxvError> {
+    let auxv_path = format!("/proc/{pid}/auxv");
+    let auxv_file = File::open(&auxv_path).map_err(|e| AuxvError::OpenError(auxv_path, e))?;
+    let auxv: HashMap<AuxvType, AuxvType> = ProcfsAuxvIter::new(BufReader::new(auxv_file))
+        .filter_map(Result::ok)
+        .map(|x| (x.key, x.value))
+        .collect();
+    if auxv.is_empty() {
+        Err(AuxvError::NoAuxvEntryFound(pid))
+    } else {
+        Ok(auxv)
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum AuxvError {
+    #[error("Failed to open file {0}")]
+    OpenError(String, #[source] std::io::Error),
+    #[error("No auxv entry found for PID {0}")]
+    NoAuxvEntryFound(Pid),
+    #[error("Invalid auxv format (should not hit EOF before AT_NULL)")]
+    InvalidFormat,
+    #[error("IO Error")]
+    IOError(#[from] std::io::Error),
+}

--- a/src/linux/auxv/reader.rs
+++ b/src/linux/auxv/reader.rs
@@ -4,26 +4,15 @@
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 // The above copyright notice and this permission notice shall be in…substantial portions of the Software.
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-use crate::errors::AuxvReaderError;
-use byteorder::{NativeEndian, ReadBytesExt};
-use std::fs::File;
-use std::io::{BufReader, Read};
 
-pub type Result<T> = std::result::Result<T, AuxvReaderError>;
-
-/// The type used in auxv keys and values.
-#[cfg(target_pointer_width = "32")]
-pub type AuxvType = u32;
-/// The type used in auxv keys and values.
-#[cfg(target_pointer_width = "64")]
-pub type AuxvType = u64;
-
-/// An auxv key-value pair.
-#[derive(Debug, PartialEq, Eq)]
-pub struct AuxvPair {
-    pub key: AuxvType,
-    pub value: AuxvType,
-}
+use {
+    super::{AuxvError, AuxvPair, AuxvType},
+    byteorder::{NativeEndian, ReadBytesExt},
+    std::{
+        fs::File,
+        io::{BufReader, Read},
+    },
+};
 
 /// An iterator across auxv pairs from procfs.
 pub struct ProcfsAuxvIter {
@@ -48,7 +37,7 @@ impl ProcfsAuxvIter {
 }
 
 impl Iterator for ProcfsAuxvIter {
-    type Item = Result<AuxvPair>;
+    type Item = Result<AuxvPair, AuxvError>;
     fn next(&mut self) -> Option<Self::Item> {
         if !self.keep_going {
             return None;
@@ -65,7 +54,7 @@ impl Iterator for ProcfsAuxvIter {
                 Ok(n) => {
                     if n == 0 {
                         // should not hit EOF before AT_NULL
-                        return Some(Err(AuxvReaderError::InvalidFormat));
+                        return Some(Err(AuxvError::InvalidFormat));
                     }
 
                     read_bytes += n;

--- a/src/linux/dso_debug.rs
+++ b/src/linux/dso_debug.rs
@@ -78,10 +78,9 @@ pub fn write_dso_debug_stream(
     blamed_thread: i32,
     auxv: &AuxvDumpInfo,
 ) -> Result<MDRawDirectory> {
-    let phnum_max = auxv
-        .get_program_header_count()
-        .ok_or(SectionDsoDebugError::CouldNotFind("AT_PHNUM in auxv"))?
-        as usize;
+    let phnum_max =
+        auxv.get_program_header_count()
+            .ok_or(SectionDsoDebugError::CouldNotFind("AT_PHNUM in auxv"))? as usize;
     let phdr = auxv
         .get_program_header_address()
         .ok_or(SectionDsoDebugError::CouldNotFind("AT_PHDR in auxv"))? as usize;

--- a/src/linux/dso_debug.rs
+++ b/src/linux/dso_debug.rs
@@ -1,5 +1,5 @@
 use crate::{
-    linux::{auxv_reader::AuxvType, errors::SectionDsoDebugError, ptrace_dumper::PtraceDumper},
+    linux::{auxv::AuxvType, errors::SectionDsoDebugError, ptrace_dumper::PtraceDumper},
     mem_writer::{write_string_to_location, Buffer, MemoryArrayWriter, MemoryWriter},
     minidump_format::*,
 };

--- a/src/linux/dso_debug.rs
+++ b/src/linux/dso_debug.rs
@@ -1,9 +1,8 @@
 use crate::{
-    linux::{auxv::AuxvType, errors::SectionDsoDebugError, ptrace_dumper::PtraceDumper},
+    linux::{auxv::AuxvDumpInfo, errors::SectionDsoDebugError, ptrace_dumper::PtraceDumper},
     mem_writer::{write_string_to_location, Buffer, MemoryArrayWriter, MemoryWriter},
     minidump_format::*,
 };
-use std::collections::HashMap;
 
 type Result<T> = std::result::Result<T, SectionDsoDebugError>;
 
@@ -77,26 +76,14 @@ pub struct RDebug {
 pub fn write_dso_debug_stream(
     buffer: &mut Buffer,
     blamed_thread: i32,
-    auxv: &HashMap<AuxvType, AuxvType>,
+    auxv: &AuxvDumpInfo,
 ) -> Result<MDRawDirectory> {
-    let at_phnum;
-    let at_phdr;
-    #[cfg(any(target_arch = "arm", all(target_os = "android", target_arch = "x86")))]
-    {
-        at_phdr = 3;
-        at_phnum = 5;
-    }
-    #[cfg(not(any(target_arch = "arm", all(target_os = "android", target_arch = "x86"))))]
-    {
-        at_phdr = libc::AT_PHDR;
-        at_phnum = libc::AT_PHNUM;
-    }
-    let phnum_max = *auxv
-        .get(&at_phnum)
+    let phnum_max = auxv
+        .get_program_header_count()
         .ok_or(SectionDsoDebugError::CouldNotFind("AT_PHNUM in auxv"))?
         as usize;
-    let phdr = *auxv
-        .get(&at_phdr)
+    let phdr = auxv
+        .get_program_header_address()
         .ok_or(SectionDsoDebugError::CouldNotFind("AT_PHDR in auxv"))? as usize;
 
     let ph = PtraceDumper::copy_from_process(

--- a/src/linux/errors.rs
+++ b/src/linux/errors.rs
@@ -1,3 +1,4 @@
+use crate::auxv::AuxvError;
 use crate::dir_section::FileWriterError;
 use crate::maps_reader::MappingInfo;
 use crate::mem_writer::MemoryWriterError;
@@ -9,10 +10,10 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum InitError {
+    #[error("failed to read auxv")]
+    ReadAuxvFailed(AuxvError),
     #[error("IO error for file {0}")]
     IOError(String, #[source] std::io::Error),
-    #[error("No auxv entry found for PID {0}")]
-    NoAuxvEntryFound(Pid),
     #[error("crash thread does not reference principal mapping")]
     PrincipalMappingNotReferenced,
     #[error("Failed Android specific late init")]
@@ -45,14 +46,6 @@ pub enum MapsReaderError {
     MmapSanityCheckFailed,
     #[error("Symlink does not match ({0} vs. {1})")]
     SymlinkError(std::path::PathBuf, std::path::PathBuf),
-}
-
-#[derive(Debug, Error)]
-pub enum AuxvReaderError {
-    #[error("Invalid auxv format (should not hit EOF before AT_NULL)")]
-    InvalidFormat,
-    #[error("IO Error")]
-    IOError(#[from] std::io::Error),
 }
 
 #[derive(Debug, Error)]

--- a/src/linux/maps_reader.rs
+++ b/src/linux/maps_reader.rs
@@ -1,4 +1,4 @@
-use crate::auxv_reader::AuxvType;
+use crate::auxv::AuxvType;
 use crate::errors::MapsReaderError;
 use byteorder::{NativeEndian, ReadBytesExt};
 use goblin::elf;

--- a/src/linux/minidump_writer.rs
+++ b/src/linux/minidump_writer.rs
@@ -1,7 +1,9 @@
 use crate::{
+    auxv::AuxvDumpInfo,
     dir_section::{DirSection, DumpBuf},
     linux::{
         app_memory::AppMemoryList,
+        auxv::DirectAuxvDumpInfo,
         crash_context::CrashContext,
         dso_debug,
         errors::{InitError, WriterError},
@@ -42,6 +44,7 @@ pub struct MinidumpWriter {
     pub crash_context: Option<CrashContext>,
     pub crashing_thread_context: CrashingThreadContext,
     pub stop_timeout: Duration,
+    pub direct_auxv_dump_info: Option<DirectAuxvDumpInfo>,
 }
 
 // This doesn't work yet:
@@ -71,6 +74,7 @@ impl MinidumpWriter {
             crash_context: None,
             crashing_thread_context: CrashingThreadContext::None,
             stop_timeout: STOP_TIMEOUT,
+            direct_auxv_dump_info: None,
         }
     }
 
@@ -117,10 +121,23 @@ impl MinidumpWriter {
         self
     }
 
+    pub fn set_direct_auxv_dump_info(
+        &mut self,
+        direct_auxv_dump_info: DirectAuxvDumpInfo,
+    ) -> &mut Self {
+        self.direct_auxv_dump_info = Some(direct_auxv_dump_info);
+        self
+    }
+
     /// Generates a minidump and writes to the destination provided. Returns the in-memory
     /// version of the minidump as well.
     pub fn dump(&mut self, destination: &mut (impl Write + Seek)) -> Result<Vec<u8>> {
-        let mut dumper = PtraceDumper::new(self.process_id, self.stop_timeout)?;
+        let auxv = self
+            .direct_auxv_dump_info
+            .clone()
+            .map(AuxvDumpInfo::from)
+            .unwrap_or_default();
+        let mut dumper = PtraceDumper::new(self.process_id, self.stop_timeout, auxv)?;
         dumper.suspend_threads()?;
         dumper.late_init()?;
 

--- a/src/linux/minidump_writer.rs
+++ b/src/linux/minidump_writer.rs
@@ -1,9 +1,9 @@
+pub use crate::linux::auxv::{AuxvType, DirectAuxvDumpInfo};
 use crate::{
     auxv::AuxvDumpInfo,
     dir_section::{DirSection, DumpBuf},
     linux::{
         app_memory::AppMemoryList,
-        auxv::DirectAuxvDumpInfo,
         crash_context::CrashContext,
         dso_debug,
         errors::{InitError, WriterError},
@@ -121,6 +121,13 @@ impl MinidumpWriter {
         self
     }
 
+    /// Directly set important Auxv info determined by the crashing process
+    ///
+    /// Since `/proc/{pid}/auxv` can sometimes be inaccessible, the calling process should prefer to transfer this
+    /// information directly using the Linux `getauxval()` call (if possible).
+    ///
+    /// Any field that is set to `0` will be considered unset. In that case, minidump-writer might try other techniques
+    /// to obtain it (like reading `/proc/{pid}/auxv`).
     pub fn set_direct_auxv_dump_info(
         &mut self,
         direct_auxv_dump_info: DirectAuxvDumpInfo,

--- a/tests/ptrace_dumper.rs
+++ b/tests/ptrace_dumper.rs
@@ -39,8 +39,12 @@ fn test_thread_list_from_parent() {
     let num_of_threads = 5;
     let mut child = start_child_and_wait_for_threads(num_of_threads);
     let pid = child.id() as i32;
-    let mut dumper = PtraceDumper::new(pid, minidump_writer::minidump_writer::STOP_TIMEOUT)
-        .expect("Couldn't init dumper");
+    let mut dumper = PtraceDumper::new(
+        pid,
+        minidump_writer::minidump_writer::STOP_TIMEOUT,
+        Default::default(),
+    )
+    .expect("Couldn't init dumper");
     assert_eq!(dumper.threads.len(), num_of_threads);
     dumper.suspend_threads().expect("Could not suspend threads");
 
@@ -216,8 +220,12 @@ fn test_sanitize_stack_copy() {
     let heap_addr = usize::from_str_radix(output.next().unwrap().trim_start_matches("0x"), 16)
         .expect("unable to parse mmap_addr");
 
-    let mut dumper = PtraceDumper::new(pid, minidump_writer::minidump_writer::STOP_TIMEOUT)
-        .expect("Couldn't init dumper");
+    let mut dumper = PtraceDumper::new(
+        pid,
+        minidump_writer::minidump_writer::STOP_TIMEOUT,
+        Default::default(),
+    )
+    .expect("Couldn't init dumper");
     assert_eq!(dumper.threads.len(), num_of_threads);
     dumper.suspend_threads().expect("Could not suspend threads");
     let thread_info = dumper


### PR DESCRIPTION
If the crashed process supports it, it can directly pass in the needed values from the auxiliary vector to avoid potential issues where "/proc/{pid}/auxv" can't be accessed on Android.

If the information is not passed in (or is incomplete), the code will attempt to fill in any gaps from the auxv file. If any of this fails, it will now just log a warning message and continue writing the minidump.

Fixes #27