### PR TITLE
Handle non-SIGSTOP signals

### DIFF
--- a/src/linux/ptrace_dumper.rs
+++ b/src/linux/ptrace_dumper.rs
@@ -160,10 +160,7 @@ impl PtraceDumper {
 
                     // Signals other than SIGSTOP that are received need to be reinjected,
                     // or they will otherwise get lost.
-                    // Note that the breakpad code doesn't do a detach, but that
-                    // feels like a bug...
                     if let Err(err) = ptrace::cont(pid, status) {
-                        ptrace_detach(child)?;
                         return Err(DumperError::WaitPidError(child, err));
                     }
                 }

--- a/tests/ptrace_dumper.rs
+++ b/tests/ptrace_dumper.rs
@@ -39,8 +39,10 @@ fn test_thread_list_from_child() {
     let _thread = std::thread::Builder::new()
         .name("sighup-thread".into())
         .spawn(move || {
-            tx.send(unsafe { libc::pthread_self() }).unwrap();
-            loop {}
+            tx.send(unsafe { libc::pthread_self() as usize }).unwrap();
+            loop {
+                std::thread::sleep(std::time::Duration::from_secs(1));
+            }
         })
         .unwrap();
 
@@ -78,7 +80,7 @@ fn test_thread_list_from_child() {
     }
 
     unsafe {
-        libc::pthread_kill(thread_id, libc::SIGHUP);
+        libc::pthread_kill(thread_id as _, libc::SIGHUP);
     }
 
     spawn_child("thread_list", &[]);

--- a/tests/ptrace_dumper.rs
+++ b/tests/ptrace_dumper.rs
@@ -31,6 +31,56 @@ fn test_setup() {
 #[test]
 fn test_thread_list_from_child() {
     // Child spawns and looks in the parent (== this process) for its own thread-ID
+
+    let (tx, rx) = std::sync::mpsc::sync_channel(1);
+
+    // // We also spawn another thread that we send a SIGHUP to to ensure that the
+    // // ptracedumper correctly handles it
+    let _thread = std::thread::Builder::new()
+        .name("sighup-thread".into())
+        .spawn(move || {
+            tx.send(unsafe { libc::pthread_self() }).unwrap();
+            loop {}
+        })
+        .unwrap();
+
+    let thread_id = rx.recv().unwrap();
+
+    // Unfortunately we need to set a signal handler to ignore the SIGHUP we send
+    // to the thread, as otherwise the default test harness fails
+    unsafe {
+        let mut act: libc::sigaction = std::mem::zeroed();
+        if libc::sigemptyset(&mut act.sa_mask) != 0 {
+            eprintln!(
+                "unable to clear action mask: {:?}",
+                std::io::Error::last_os_error()
+            );
+            return;
+        }
+
+        unsafe extern "C" fn on_sig(
+            _sig: libc::c_int,
+            _info: *mut libc::siginfo_t,
+            _uc: *mut libc::c_void,
+        ) {
+        }
+
+        act.sa_flags = libc::SA_SIGINFO;
+        act.sa_sigaction = on_sig as usize;
+
+        // Register the action with the signal handler
+        if libc::sigaction(libc::SIGHUP, &act, std::ptr::null_mut()) != 0 {
+            eprintln!(
+                "unable to register signal handler: {:?}",
+                std::io::Error::last_os_error()
+            );
+        }
+    }
+
+    unsafe {
+        libc::pthread_kill(thread_id, libc::SIGHUP);
+    }
+
     spawn_child("thread_list", &[]);
 }
 


### PR DESCRIPTION
- **Handle non-SIGSTOP signals**
- **Add failed attempt to test**

This just implements the code pointed out in #124. I attempted to add a test for this by starting another named thread and sending a SIGHUP to it before spawning the dumper, but I don't think this scenario will ever result in the new code being run.

Resolve: #124