### PR TITLE
Respect `MADV_DONTDUMP`

### DIFF
--- a/src/linux/ptrace_dumper.rs
+++ b/src/linux/ptrace_dumper.rs
@@ -313,7 +313,7 @@ impl PtraceDumper {
         // guaranteed (see http://crosbug.com/25355); therefore, try to use the
         // actual entry point to find the mapping.
         let entry_point_loc = self.auxv.get_entry_address().unwrap_or_default();
-        let filename = format!("/proc/{}/maps", self.pid);
+        let filename = format!("/proc/{}/smaps", self.pid);
         let errmap = |e| InitError::IOError(filename.clone(), e);
         let maps_path = path::PathBuf::from(&filename);
         let maps_file = std::fs::File::open(maps_path).map_err(errmap)?;
@@ -516,7 +516,8 @@ impl PtraceDumper {
         Ok(())
     }
 
-    // Find the mapping which the given memory address falls in.
+    /// Find the mapping which the given memory address falls in.
+    #[inline]
     pub fn find_mapping(&self, address: usize) -> Option<&MappingInfo> {
         self.mappings
             .iter()

--- a/tests/linux_minidump_writer.rs
+++ b/tests/linux_minidump_writer.rs
@@ -164,6 +164,7 @@ contextual_test! {
                 start_address: mmap_addr,
                 end_address: mmap_addr + memory_size,
             },
+            madvise_dontdump: false,
         };
 
         let identifier = vec![


### PR DESCRIPTION
This changes ptrace to look at `/proc/{pid}/smaps` instead of `/proc/{pid}/maps` so that we can detect madvise flags, notably `dd` `MADV_DONTDUMP`, and ignore writing those mappings to the minidump.

Resolves: #130 