### PR TITLE
Windows dump_crash_context take reference to crash_context

### DIFF
--- a/src/linux/dumper_cpu_info/x86_mips.rs
+++ b/src/linux/dumper_cpu_info/x86_mips.rs
@@ -111,7 +111,7 @@ pub fn write_cpu_information(sys_info: &mut MDRawSystemInfo) -> Result<()> {
     {
         sys_info.processor_level = cpu_info_table[3].value as u16;
         sys_info.processor_revision =
-            (cpu_info_table[1].value << 8 | cpu_info_table[2].value) as u16;
+            ((cpu_info_table[1].value << 8) | cpu_info_table[2].value) as u16;
     }
     if !vendor_id.is_empty() {
         let vendor_id = vendor_id.as_bytes();

--- a/src/windows/minidump_writer.rs
+++ b/src/windows/minidump_writer.rs
@@ -130,7 +130,7 @@ impl MinidumpWriter {
                 exception_code,
             };
 
-            Self::dump_crash_context(cc, minidump_type, destination)
+            Self::dump_crash_context(&cc, minidump_type, destination)
         }
     }
 
@@ -149,7 +149,7 @@ impl MinidumpWriter {
     /// is the responsibility of the caller to ensure that the pointer is valid
     /// for the duration of this function call.
     pub fn dump_crash_context(
-        crash_context: crash_context::CrashContext,
+        crash_context: &crash_context::CrashContext,
         minidump_type: Option<MinidumpType>,
         destination: &mut std::fs::File,
     ) -> Result<(), Error> {

--- a/tests/windows_minidump_writer.rs
+++ b/tests/windows_minidump_writer.rs
@@ -164,7 +164,7 @@ fn dump_external_process() {
 
     // SAFETY: We keep the process we are dumping alive until the minidump is written
     // and the test process keep the pointers it sent us alive until it is killed
-    MinidumpWriter::dump_crash_context(crash_context, None, tmpfile.as_file_mut())
+    MinidumpWriter::dump_crash_context(&crash_context, None, tmpfile.as_file_mut())
         .expect("failed to write minidump");
 
     child.kill().expect("failed to kill child");


### PR DESCRIPTION
`dump_crash_context` only read values of `CrashContext`, so we can just pass in the reference and don't need to pass the value. This is useful when used with [crash handler](https://github.com/EmbarkStudios/crash-handling).

For example, currently the code below wouldn't work, and `crash_context` can't be converted to type `CrashContext` since it doesn't implement `Copy` trait

```
  CRASH_HANDLER
      .set(
          crash_handler::CrashHandler::attach(unsafe {
              crash_handler::make_crash_event(|crash_context| {  // <- This is of type &CrashContext
                  let mut minidump_file = std::fs::File::create("dump.mdmp").expect("failed to create file");

                  minidump_writer::minidump_writer::MinidumpWriter::dump_crash_context(
                      crash_context,
                      None,
                      &mut minidump_file,
                  );

                  crash_handler::CrashEventResult::Handled(false)
              })
          })
          .expect("CrashHandler should be initialized"),
      )
      .expect("CRASH_HANDLER should be set");
```