### PR TITLE
Fix Yama blocking child-to-parent ptrace

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -9,6 +9,12 @@ type Error = Box<dyn error::Error + std::marker::Send + std::marker::Sync>;
 pub type Result<T> = result::Result<T, Error>;
 
 fn build_command() -> Command {
+    // Anything that needs to spawn a child will need to give it permission to
+    // ptrace itself, as Yama LSM will normally only allow a parent to debug
+    // a child, not the other way around.
+    let rc = unsafe { libc::prctl(libc::PR_SET_PTRACER, libc::PR_SET_PTRACER_ANY) };
+    assert_eq!(rc, 0);
+
     let mut cmd;
     if let Some(binary) = std::env::var_os("TEST_HELPER") {
         cmd = Command::new(binary);

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -12,8 +12,11 @@ fn build_command() -> Command {
     // Anything that needs to spawn a child will need to give it permission to
     // ptrace itself, as Yama LSM will normally only allow a parent to debug
     // a child, not the other way around.
-    let rc = unsafe { libc::prctl(libc::PR_SET_PTRACER, libc::PR_SET_PTRACER_ANY) };
-    assert_eq!(rc, 0);
+    #[cfg(target_os = "linux")]
+    {
+        let rc = unsafe { libc::prctl(libc::PR_SET_PTRACER, libc::PR_SET_PTRACER_ANY) };
+        assert_eq!(rc, 0);
+    }
 
     let mut cmd;
     if let Some(binary) = std::env::var_os("TEST_HELPER") {


### PR DESCRIPTION
Currently, there are three tests that fail on my Ubuntu machine because I have the Yama security module enabled, and it ensures that a process can only be `ptrace()`ed by its own parent.

Our testing relies on the opposite -- A child `ptrace()`ing its parent, which is not allowed until a call is made to `prctl()` to allow it.