### PR TITLE
Bug 1831094: Add a process reader and module reader for each platform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1432,6 +1432,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "uuid",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ license = "MIT"
 bitflags = "2.10"
 cfg-if = "1.0"
 crash-context = "0.6"
+error-graph = { version = "0.1.1", features = ["serde"] }
+failspot = "0.2.0"
+# goblin >= 0.10 uses scroll 0.13
+goblin = "0.9.2"
 log = "0.4"
 # Type definitions and utilities for working with the Minidump format
 minidump-common = "0.26"
@@ -24,8 +28,6 @@ thiserror = "2.0"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
-# goblin >= 0.10 uses scroll 0.13
-goblin = "0.9"
 memmap2 = "0.9"
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
@@ -46,6 +48,11 @@ procfs-core = { version = "0.18", default-features = false, features = ["serde1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 bitflags = "2.4"
+windows-sys = { version = ">=0.52", features = [
+    "Win32_Foundation",
+    "Win32_System_Diagnostics_Debug",
+    "Win32_System_ProcessStatus",
+] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # Binds some additional mac specifics not in libc, note that other dependents

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -77,7 +77,7 @@ mod linux {
     }
 
     fn test_copy_from_process(stack_var: usize, heap_var: usize) -> Result<()> {
-        use minidump_writer::mem_reader::MemReader;
+        use minidump_writer::process_reader::ProcessReader;
 
         let ppid = getppid().as_raw();
         let dumper = fail_on_soft_error!(
@@ -91,7 +91,7 @@ mod linux {
         let expected_stack = 0x11223344usize.to_ne_bytes();
         let expected_heap = 0x55667788usize.to_ne_bytes();
 
-        let validate = |reader: &mut MemReader| -> Result<()> {
+        let validate = |reader: &mut ProcessReader| -> Result<()> {
             let mut val = [0u8; std::mem::size_of::<usize>()];
             let read = reader.read(stack_var, &mut val)?;
             assert_eq!(read, val.len());
@@ -106,14 +106,14 @@ mod linux {
 
         // virtual mem
         {
-            let mut mr = MemReader::for_virtual_mem(ppid);
+            let mut mr = ProcessReader::for_virtual_mem(ppid);
             validate(&mut mr)
                 .map_err(|err| format!("failed to validate memory for {mr:?}: {err}"))?;
         }
 
         // file
         {
-            let mut mr = MemReader::for_file(ppid)
+            let mut mr = ProcessReader::for_file(ppid)
                 .map_err(|err| format!("failed to open `/proc/{ppid}/mem`: {err}"))?;
             validate(&mut mr)
                 .map_err(|err| format!("failed to validate memory for {mr:?}: {err}"))?;
@@ -121,7 +121,7 @@ mod linux {
 
         // ptrace
         {
-            let mut mr = MemReader::for_ptrace(ppid);
+            let mut mr = ProcessReader::for_ptrace(ppid);
             validate(&mut mr)
                 .map_err(|err| format!("failed to validate memory for {mr:?}: {err}"))?;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,5 +28,7 @@ pub mod dir_section;
 pub mod mem_writer;
 pub mod minidump_cpu;
 pub mod minidump_format;
+pub mod module_reader;
+pub mod process_reader;
 
 mod serializers;

--- a/src/linux/android.rs
+++ b/src/linux/android.rs
@@ -1,7 +1,7 @@
 use {
     super::{
-        Pid, maps_reader::MappingInfo, mem_reader::CopyFromProcessError,
-        minidump_writer::MinidumpWriter,
+        Pid, maps_reader::MappingInfo, minidump_writer::MinidumpWriter,
+        process_reader::CopyFromProcessError,
     },
     goblin::elf,
 };

--- a/src/linux/dso_debug.rs
+++ b/src/linux/dso_debug.rs
@@ -1,6 +1,6 @@
 use {
     super::{
-        auxv::AuxvDumpInfo, mem_reader::CopyFromProcessError, minidump_writer::MinidumpWriter,
+        auxv::AuxvDumpInfo, minidump_writer::MinidumpWriter, process_reader::CopyFromProcessError,
         serializers::*,
     },
     crate::{

--- a/src/linux/maps_reader.rs
+++ b/src/linux/maps_reader.rs
@@ -4,7 +4,10 @@ use {
     byteorder::{NativeEndian, ReadBytesExt},
     goblin::elf,
     memmap2::{Mmap, MmapOptions},
-    procfs_core::process::{MMPermissions, MMapPath, MemoryMaps},
+    procfs_core::{
+        FromRead,
+        process::{MMPermissions, MMapPath, MemoryMaps},
+    },
     std::{
         ffi::{OsStr, OsString},
         fs::File,
@@ -96,6 +99,14 @@ pub enum MapsReaderError {
     MmapSanityCheckFailed,
     #[error("Symlink does not match ({0} vs. {1})")]
     SymlinkError(std::path::PathBuf, std::path::PathBuf),
+    #[error("Mappings file missing for pid {pid} (is the process still alive?)")]
+    MappingFileMissing { pid: i32 },
+    #[error("Failed to parse memory maps file")]
+    ParsingError(
+        #[from]
+        #[serde(serialize_with = "serialize_proc_error")]
+        procfs_core::ProcError,
+    ),
 }
 
 fn is_mapping_a_path(pathname: Option<&OsStr>) -> bool {
@@ -117,6 +128,20 @@ fn sanitize_path(pathname: OsString) -> OsString {
 }
 
 impl MappingInfo {
+    /// Get the mappings for the given process.
+    pub fn for_pid(pid: i32, linux_gate_loc: Option<AuxvType>) -> Result<Vec<Self>> {
+        let maps_path = format!("/proc/{}/maps", pid);
+        let maps_file = File::open(&maps_path).map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                MapsReaderError::MappingFileMissing { pid }
+            } else {
+                e.into()
+            }
+        })?;
+        let maps = MemoryMaps::from_read(maps_file)?;
+        Self::aggregate(maps, linux_gate_loc)
+    }
+
     /// Return whether the `name` field is a path (contains a `/`).
     pub fn name_is_path(&self) -> bool {
         is_mapping_a_path(self.name.as_deref())

--- a/src/linux/minidump_writer/errors.rs
+++ b/src/linux/minidump_writer/errors.rs
@@ -200,12 +200,6 @@ pub enum InitError {
     EnumerateThreadsErrors(#[source] ErrorList<InitError>),
     #[error("Failed to enumerate threads")]
     EnumerateThreadsFailed(#[source] Box<InitError>),
-    #[error("Failed to read process map file")]
-    ReadProcessMapFileFailed(
-        #[source]
-        #[serde(serialize_with = "serialize_proc_error")]
-        ProcError,
-    ),
     #[error("Failed to aggregate process mappings")]
     AggregateMappingsFailed(#[source] MapsReaderError),
     #[error("Failed to enumerate process mappings")]

--- a/src/linux/minidump_writer/mod.rs
+++ b/src/linux/minidump_writer/mod.rs
@@ -7,7 +7,7 @@ use {
         dso_debug,
         dumper_cpu_info::CpuInfoError,
         maps_reader::{MappingInfo, MappingList, MapsReaderError},
-        mem_reader::CopyFromProcessError,
+        mem_reader::{CopyFromProcessError, MemReader},
         module_reader,
         serializers::*,
         thread_info::{ThreadInfo, ThreadInfoError},
@@ -953,8 +953,9 @@ impl MinidumpWriter {
         mapping: &MappingInfo,
         pid: Pid,
     ) -> Result<T, WriterError> {
+        let mem_reader = MemReader::new(pid);
         Ok(T::read_from_module(
-            module_reader::ProcessReader::new(pid, mapping.start_address).into(),
+            module_reader::ModuleMemory::from_process(&mem_reader, mapping.start_address),
         )?)
     }
 }

--- a/src/linux/minidump_writer/mod.rs
+++ b/src/linux/minidump_writer/mod.rs
@@ -7,8 +7,7 @@ use {
         dso_debug,
         dumper_cpu_info::CpuInfoError,
         maps_reader::{MappingInfo, MappingList, MapsReaderError},
-        mem_reader::{CopyFromProcessError, MemReader},
-        module_reader,
+        process_reader::{CopyFromProcessError, ProcessReader},
         serializers::*,
         thread_info::{ThreadInfo, ThreadInfoError},
     },
@@ -18,6 +17,7 @@ use {
             Buffer, MemoryArrayWriter, MemoryWriter, MemoryWriterError, write_string_to_location,
         },
         minidump_format::*,
+        module_reader,
         serializers::*,
     },
     error_graph::{ErrorList, WriteErrorList},
@@ -720,14 +720,7 @@ impl MinidumpWriter {
         // case its entry when creating the list of mappings.
         // See http://www.trilithium.com/johan/2005/08/linux-gate/ for more
         // information.
-        let maps_path = format!("/proc/{}/maps", self.process_id);
-        let maps_file =
-            std::fs::File::open(&maps_path).map_err(|e| InitError::IOError(maps_path, e))?;
-
-        let maps = procfs_core::process::MemoryMaps::from_read(maps_file)
-            .map_err(InitError::ReadProcessMapFileFailed)?;
-
-        self.mappings = MappingInfo::aggregate(maps, self.auxv.get_linux_gate_address())
+        self.mappings = MappingInfo::for_pid(self.process_id, self.auxv.get_linux_gate_address())
             .map_err(InitError::AggregateMappingsFailed)?;
 
         // Although the initial executable is usually the first mapping, it's not
@@ -953,10 +946,33 @@ impl MinidumpWriter {
         mapping: &MappingInfo,
         pid: Pid,
     ) -> Result<T, WriterError> {
-        let mem_reader = MemReader::new(pid);
+        let reader = ProcessReader::new(pid);
         Ok(T::read_from_module(
-            module_reader::ModuleMemory::from_process(&mem_reader, mapping.start_address),
+            module_reader::ModuleMemory::from_process(&reader, mapping.start_address),
         )?)
+    }
+
+    /// Copies a block of bytes from the target process, returning the heap
+    /// allocated copy
+    #[inline]
+    pub fn copy_from_process(
+        pid: Pid,
+        src: usize,
+        length: usize,
+    ) -> Result<Vec<u8>, CopyFromProcessError> {
+        let length = std::num::NonZeroUsize::new(length).ok_or(CopyFromProcessError {
+            src,
+            child: pid,
+            offset: 0,
+            length,
+            // TODO: We should make copy_from_process also take a NonZero,
+            // as EINVAL could also come from the syscalls that actually read
+            // memory as well which could be confusing
+            source: nix::errno::Errno::EINVAL,
+        })?;
+
+        let mem = ProcessReader::new(pid);
+        mem.read_to_vec(src, length)
     }
 }
 

--- a/src/linux/minidump_writer/thread_list_stream.rs
+++ b/src/linux/minidump_writer/thread_list_stream.rs
@@ -96,8 +96,9 @@ impl MinidumpWriter {
             // we used the actual state of the thread we would find it running in the
             // signal handler with the alternative stack, which would be deeply
             // unhelpful.
-            if self.crash_context.is_some() && thread.thread_id == self.blamed_thread as u32 {
-                let crash_context = self.crash_context.as_ref().unwrap();
+            if let Some(crash_context) = &self.crash_context
+                && thread.thread_id == self.blamed_thread as u32
+            {
                 let instruction_ptr = crash_context.get_instruction_pointer();
                 let stack_pointer = crash_context.get_stack_pointer();
                 self.fill_thread_stack(

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -9,9 +9,9 @@ pub mod crash_context;
 mod dso_debug;
 mod dumper_cpu_info;
 pub mod maps_reader;
-pub mod mem_reader;
 pub mod minidump_writer;
 pub mod module_reader;
+pub mod process_reader;
 mod serializers;
 pub mod thread_info;
 

--- a/src/linux/module_reader.rs
+++ b/src/linux/module_reader.rs
@@ -1,5 +1,6 @@
 use {
-    super::{mem_reader::MemReader, serializers::*},
+    super::serializers::*,
+    crate::module_reader::{ModuleMemory, ModuleMemoryReadError},
     crate::{minidump_format::GUID, serializers::*},
     goblin::{
         container::{Container, Ctx, Endian},
@@ -8,7 +9,6 @@ use {
     std::{borrow::Cow, ffi::CStr},
 };
 
-type Buf<'buf> = Cow<'buf, [u8]>;
 type Error = ModuleReaderError;
 
 const NOTE_SECTION_NAME: &[u8] = b".note.gnu.build-id\0";
@@ -22,15 +22,8 @@ pub enum ModuleReaderError {
         #[serde(serialize_with = "serialize_io_error")]
         error: std::io::Error,
     },
-    #[error("failed to read module memory: {length} bytes at {offset}{}: {error}", .start_address.map(|addr| format!(" (start address: {addr})")).unwrap_or_default())]
-    ReadModuleMemory {
-        offset: u64,
-        length: u64,
-        start_address: Option<u64>,
-        #[source]
-        #[serde(serialize_with = "serialize_nix_error")]
-        error: nix::Error,
-    },
+    #[error(transparent)]
+    ReadModuleMemory(#[from] ModuleMemoryReadError),
     #[error("failed to parse ELF memory: {0}")]
     Parsing(
         #[from]
@@ -79,77 +72,9 @@ pub enum ModuleReaderError {
     },
 }
 
-pub enum ModuleMemory<'a> {
-    Slice(&'a [u8]),
-    Process {
-        reader: &'a MemReader,
-        start_address: u64,
-    },
-}
-
-impl<'buf> From<&'buf [u8]> for ModuleMemory<'buf> {
-    fn from(value: &'buf [u8]) -> Self {
-        Self::Slice(value)
-    }
-}
-
-impl<'a> ModuleMemory<'a> {
-    pub fn from_process(reader: &'a MemReader, start_address: usize) -> Self {
-        Self::Process {
-            reader,
-            start_address: start_address as u64,
-        }
-    }
-
-    #[inline]
-    fn read(&mut self, offset: u64, length: u64) -> Result<Buf<'a>, Error> {
-        let error = move |start_address, error| Error::ReadModuleMemory {
-            start_address,
-            offset,
-            length,
-            error,
-        };
-
-        match self {
-            Self::Process {
-                reader,
-                start_address,
-            } => {
-                let error = |e| error(Some(*start_address), e);
-                let len = std::num::NonZeroUsize::new(length as usize)
-                    .ok_or_else(|| error(nix::Error::EINVAL))?;
-                let proc_offset = start_address
-                    .checked_add(offset)
-                    .ok_or_else(|| error(nix::Error::EOVERFLOW))?;
-                reader
-                    .read_to_vec(proc_offset as _, len)
-                    .map(Cow::Owned)
-                    .map_err(|err| error(err.source))
-            }
-            Self::Slice(s) => {
-                let error = |e| error(None, e);
-                let end = offset
-                    .checked_add(length)
-                    .ok_or_else(|| error(nix::Error::EOVERFLOW))?;
-                s.get(offset as usize..end as usize)
-                    .map(Cow::Borrowed)
-                    .ok_or_else(|| error(nix::Error::EACCES))
-            }
-        }
-    }
-
-    /// Calculates the absolute address of the specified relative address
-    #[inline]
-    fn absolute(&self, addr: u64) -> u64 {
-        let Self::Process { start_address, .. } = self else {
-            return addr;
-        };
-        addr.checked_sub(*start_address).unwrap_or(addr)
-    }
-
-    #[inline]
-    fn is_process_memory(&self) -> bool {
-        matches!(self, Self::Process { .. })
+impl crate::module_reader::ModuleMemory<'_> {
+    pub fn read_from_module<T: ReadFromModule>(self) -> Result<T, Error> {
+        T::read_from_module(self)
     }
 }
 
@@ -184,7 +109,7 @@ fn section_header_with_name<'sc>(
     section_headers: &'sc elf::SectionHeaders,
     strtab_index: usize,
     name: &[u8],
-    module_memory: &mut ModuleMemory<'_>,
+    module_memory: &ModuleMemory<'_>,
 ) -> Result<Option<&'sc elf::SectionHeader>, Error> {
     let strtab_section_header = section_headers
         .get(strtab_index)
@@ -230,7 +155,7 @@ pub struct BuildId(pub Vec<u8>);
 
 impl ReadFromModule for BuildId {
     fn read_from_module(module_memory: ModuleMemory<'_>) -> Result<Self, Error> {
-        let mut reader = ModuleReader::new(module_memory)?;
+        let reader = ModuleReader::new(module_memory)?;
         let program_headers = match reader.build_id_from_program_headers() {
             Ok(v) => return Ok(BuildId(v)),
             Err(e) => Box::new(e),
@@ -290,7 +215,7 @@ pub struct SoName(pub String);
 
 impl ReadFromModule for SoName {
     fn read_from_module(module_memory: ModuleMemory<'_>) -> Result<Self, Error> {
-        let mut reader = ModuleReader::new(module_memory)?;
+        let reader = ModuleReader::new(module_memory)?;
         let program_headers = match reader.soname_from_program_headers() {
             Ok(v) => return Ok(SoName(v)),
             Err(e) => Box::new(e),
@@ -313,7 +238,7 @@ pub struct ModuleReader<'buf> {
 }
 
 impl<'buf> ModuleReader<'buf> {
-    pub fn new(mut module_memory: ModuleMemory<'buf>) -> Result<Self, Error> {
+    pub fn new(module_memory: ModuleMemory<'buf>) -> Result<Self, Error> {
         // We could use `Ctx::default()` (which defaults to the native system), however to be extra
         // permissive we'll just use a 64-bit ("Big") context which would result in the largest
         // possible header size.
@@ -329,8 +254,38 @@ impl<'buf> ModuleReader<'buf> {
         })
     }
 
+    /// Find a note referenced by the program headers.
+    pub fn find_program_note(
+        &self,
+        note_type: u32,
+        note_size: usize,
+        note_name: &str,
+    ) -> Result<Option<Vec<u8>>, Error> {
+        let program_headers = self.read_program_headers()?;
+        for header in program_headers {
+            if header.p_type != elf::program_header::PT_NOTE
+                || (header.p_flags & elf::program_header::PF_R) == 0
+                || (header.p_memsz as usize) < note_size
+            {
+                continue;
+            }
+
+            if let Some(data) = self.find_note(
+                header.p_offset,
+                header.p_filesz,
+                header.p_align,
+                note_type,
+                note_size,
+                note_name,
+            )? {
+                return Ok(Some(data));
+            }
+        }
+        Ok(None)
+    }
+
     /// Read the SONAME using program headers to locate dynamic library information.
-    pub fn soname_from_program_headers(&mut self) -> Result<String, Error> {
+    pub fn soname_from_program_headers(&self) -> Result<String, Error> {
         let program_headers = self.read_program_headers()?;
 
         let dynamic_segment_header = program_headers
@@ -359,7 +314,13 @@ impl<'buf> ModuleReader<'buf> {
             (Some(addr), Some(size), Some(offset)) => {
                 // If loaded in memory, the address will be altered to be absolute.
                 if offset < size {
-                    self.read_name_from_strtab(self.module_memory.absolute(addr), size, offset)
+                    self.read_name_from_strtab(
+                        self.module_memory
+                            .absolute_to_relative(addr)
+                            .unwrap_or(addr),
+                        size,
+                        offset,
+                    )
                 } else {
                     log::warn!("soname strtab offset ({offset}) exceeds strtab size ({size})");
                     Err(Error::NoSoNameEntry)
@@ -369,7 +330,7 @@ impl<'buf> ModuleReader<'buf> {
     }
 
     /// Read the SONAME using section headers to locate dynamic library information.
-    pub fn soname_from_sections(&mut self) -> Result<String, Error> {
+    pub fn soname_from_sections(&self) -> Result<String, Error> {
         let section_headers = self.read_section_headers()?;
 
         let dynamic_section_header = section_headers
@@ -384,7 +345,7 @@ impl<'buf> ModuleReader<'buf> {
                     &section_headers,
                     self.header.e_shstrndx as usize,
                     b".dynstr\0",
-                    &mut self.module_memory,
+                    &self.module_memory,
                 )?
                 .ok_or(Error::NoDynStrSection)?,
             };
@@ -417,7 +378,7 @@ impl<'buf> ModuleReader<'buf> {
     }
 
     /// Read the build id from a program header note.
-    pub fn build_id_from_program_headers(&mut self) -> Result<Vec<u8>, Error> {
+    pub fn build_id_from_program_headers(&self) -> Result<Vec<u8>, Error> {
         let program_headers = self.read_program_headers()?;
         for header in program_headers {
             if header.p_type != elf::program_header::PT_NOTE {
@@ -433,14 +394,14 @@ impl<'buf> ModuleReader<'buf> {
     }
 
     /// Read the build id from a notes section.
-    pub fn build_id_from_section(&mut self) -> Result<Vec<u8>, Error> {
+    pub fn build_id_from_section(&self) -> Result<Vec<u8>, Error> {
         let section_headers = self.read_section_headers()?;
 
         let header = section_header_with_name(
             &section_headers,
             self.header.e_shstrndx as usize,
             NOTE_SECTION_NAME,
-            &mut self.module_memory,
+            &self.module_memory,
         )?
         .ok_or(Error::NoSectionNote)?;
 
@@ -452,7 +413,7 @@ impl<'buf> ModuleReader<'buf> {
     }
 
     /// Generate a build id by hashing the first page of the text section.
-    pub fn build_id_generate_from_text(&mut self) -> Result<Vec<u8>, Error> {
+    pub fn build_id_generate_from_text(&self) -> Result<Vec<u8>, Error> {
         let Some(text_header) = self
             .read_section_headers()?
             .into_iter()
@@ -467,18 +428,18 @@ impl<'buf> ModuleReader<'buf> {
         Ok(build_id_from_bytes(&text_data))
     }
 
-    fn read_segment(&mut self, header: &elf::ProgramHeader) -> Result<Buf<'buf>, Error> {
+    fn read_segment(&self, header: &elf::ProgramHeader) -> Result<Cow<'buf, [u8]>, Error> {
         let (offset, size) = if self.module_memory.is_process_memory() {
             (header.p_vaddr, header.p_memsz)
         } else {
             (header.p_offset, header.p_filesz)
         };
 
-        self.module_memory.read(offset, size)
+        self.module_memory.read(offset, size).map_err(|e| e.into())
     }
 
     fn read_name_from_strtab(
-        &mut self,
+        &self,
         strtab_offset: u64,
         strtab_size: u64,
         name_offset: u64,
@@ -500,7 +461,7 @@ impl<'buf> ModuleReader<'buf> {
         }
     }
 
-    fn read_program_headers(&mut self) -> Result<elf::ProgramHeaders, Error> {
+    fn read_program_headers(&self) -> Result<elf::ProgramHeaders, Error> {
         if self.header.e_phoff == 0 {
             return Err(Error::NoProgramHeaders);
         }
@@ -517,7 +478,7 @@ impl<'buf> ModuleReader<'buf> {
         Ok(program_headers)
     }
 
-    fn read_section_headers(&mut self) -> Result<elf::SectionHeaders, Error> {
+    fn read_section_headers(&self) -> Result<elf::SectionHeaders, Error> {
         if self.header.e_shoff == 0 {
             return Err(Error::NoSections);
         }
@@ -537,10 +498,29 @@ impl<'buf> ModuleReader<'buf> {
     }
 
     fn find_build_id_note(
-        &mut self,
+        &self,
         offset: u64,
         size: u64,
         alignment: u64,
+    ) -> Result<Option<Vec<u8>>, Error> {
+        self.find_note(
+            offset,
+            size,
+            alignment,
+            elf::note::NT_GNU_BUILD_ID,
+            0,
+            "GNU",
+        )
+    }
+
+    fn find_note(
+        &self,
+        offset: u64,
+        size: u64,
+        alignment: u64,
+        note_type: u32,
+        note_min_size: usize,
+        note_name: &str,
     ) -> Result<Option<Vec<u8>>, Error> {
         let notes = self.module_memory.read(offset, size)?;
         for note in (elf::note::NoteDataIterator {
@@ -552,10 +532,136 @@ impl<'buf> ModuleReader<'buf> {
             ctx: (alignment as usize, self.context),
         }) {
             let Ok(note) = note else { break };
-            if note.name == "GNU" && note.n_type == elf::note::NT_GNU_BUILD_ID {
+            if note.name == note_name
+                && note.n_type == note_type
+                && note.desc.len() >= note_min_size
+            {
                 return Ok(Some(note.desc.to_owned()));
             }
         }
         Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// This is a small (but valid) 64-bit little-endian elf executable with the following layout:
+    /// * ELF header
+    /// * program header: text segment
+    /// * program header: note
+    /// * program header: dynamic
+    /// * section header: null
+    /// * section header: .text
+    /// * section header: .note.gnu.build-id
+    /// * section header: .shstrtab
+    /// * section header: .dynamic
+    /// * section header: .dynstr
+    /// * note header (build id note)
+    /// * shstrtab
+    /// * dynamic (SONAME/STRTAB/STRSZ)
+    /// * dynstr (SONAME string = libfoo.so.1)
+    /// * program (calls exit(0))
+    const TINY_ELF: &[u8] = &[
+        0x7f, 0x45, 0x4c, 0x46, 0x02, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x02, 0x00, 0x3e, 0x00, 0x01, 0x00, 0x00, 0x00, 0x0a, 0x03, 0x40, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xe8, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00, 0x38, 0x00, 0x03, 0x00, 0x40, 0x00,
+        0x06, 0x00, 0x03, 0x00, 0x01, 0x00, 0x00, 0x00, 0x07, 0x00, 0x00, 0x00, 0x0a, 0x03, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x0a, 0x03, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x07,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x68, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x68, 0x02, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0xbd, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xbd, 0x02, 0x40,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+        0x01, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0a, 0x03, 0x40,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x0a, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x07, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x07, 0x00, 0x00, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x68, 0x02, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x68, 0x02, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x1a, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x88, 0x02, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x88, 0x02,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x35, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x24, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00,
+        0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xbd, 0x02, 0x40, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0xbd, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x2d, 0x00, 0x00,
+        0x00, 0x03, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xfd, 0x02,
+        0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0xfd, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0d,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x04, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x47, 0x4e,
+        0x55, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,
+        0x0e, 0x0f, 0x10, 0x00, 0x2e, 0x74, 0x65, 0x78, 0x74, 0x00, 0x2e, 0x6e, 0x6f, 0x74, 0x65,
+        0x2e, 0x67, 0x6e, 0x75, 0x2e, 0x62, 0x75, 0x69, 0x6c, 0x64, 0x2d, 0x69, 0x64, 0x00, 0x2e,
+        0x73, 0x68, 0x73, 0x74, 0x72, 0x74, 0x61, 0x62, 0x00, 0x2e, 0x64, 0x79, 0x6e, 0x61, 0x6d,
+        0x69, 0x63, 0x00, 0x2e, 0x64, 0x79, 0x6e, 0x73, 0x74, 0x72, 0x00, 0x0e, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0xfd, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0a, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x6c, 0x69, 0x62, 0x66, 0x6f, 0x6f, 0x2e, 0x73, 0x6f, 0x2e, 0x31, 0x00, 0x6a, 0x3c,
+        0x58, 0x31, 0xff, 0x0f, 0x05,
+    ];
+
+    #[test]
+    fn build_id_program_headers() {
+        let reader = ModuleReader::new(TINY_ELF.into()).unwrap();
+        let id = reader.build_id_from_program_headers().unwrap();
+        assert_eq!(
+            id,
+            vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+        );
+    }
+
+    #[test]
+    fn build_id_section() {
+        let reader = ModuleReader::new(TINY_ELF.into()).unwrap();
+        let id = reader.build_id_from_section().unwrap();
+        assert_eq!(
+            id,
+            vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+        );
+    }
+
+    #[test]
+    fn build_id_text_hash() {
+        let reader = ModuleReader::new(TINY_ELF.into()).unwrap();
+        let id = reader.build_id_generate_from_text().unwrap();
+        assert_eq!(
+            id,
+            vec![
+                0x6a, 0x3c, 0x58, 0x31, 0xff, 0x0f, 0x05, 0, 0, 0, 0, 0, 0, 0, 0, 0
+            ]
+        );
+    }
+
+    #[test]
+    fn soname_program_headers() {
+        let reader = ModuleReader::new(TINY_ELF.into()).unwrap();
+        let soname = reader.soname_from_program_headers().unwrap();
+        assert_eq!(soname, "libfoo.so.1");
+    }
+
+    #[test]
+    fn soname_section() {
+        let reader = ModuleReader::new(TINY_ELF.into()).unwrap();
+        let soname = reader.soname_from_sections().unwrap();
+        assert_eq!(soname, "libfoo.so.1");
     }
 }

--- a/src/linux/process_reader.rs
+++ b/src/linux/process_reader.rs
@@ -1,0 +1,266 @@
+use {
+    super::{Pid, maps_reader::MappingInfo, serializers::*},
+    crate::module_reader::ModuleMemory,
+    std::sync::OnceLock,
+};
+
+#[cfg(target_os = "android")]
+use super::module_reader::SoName;
+
+pub type ProcessHandle = libc::pid_t;
+
+#[derive(Debug)]
+enum Style {
+    /// Uses [`process_vm_readv`](https://linux.die.net/man/2/process_vm_readv)
+    /// to read the memory.
+    ///
+    /// This is not available on old <3.2 (really, ancient) kernels, and requires
+    /// the same permissions as ptrace
+    VirtualMem,
+    /// Reads the memory from `/proc/<pid>/mem`
+    ///
+    /// Available on basically all versions of Linux, but could fail if the process
+    /// has insufficient privileges, ie ptrace
+    File(std::fs::File),
+    /// Reads the memory with [ptrace (`PTRACE_PEEKDATA`)](https://man7.org/linux/man-pages/man2/ptrace.2.html)
+    ///
+    /// Reads data one word at a time, so slow, but fairly reliable, as long as
+    /// the process can be ptraced
+    Ptrace,
+    /// No methods succeeded, generally there isn't a case where failing a syscall
+    /// will work if called again
+    Unavailable {
+        vmem: nix::Error,
+        file: nix::Error,
+        ptrace: nix::Error,
+    },
+}
+
+#[derive(Debug, thiserror::Error, serde::Serialize)]
+#[error("Copy from process {child} failed (source {src}, offset: {offset}, length: {length})")]
+pub struct CopyFromProcessError {
+    pub child: Pid,
+    pub src: usize,
+    pub offset: usize,
+    pub length: usize,
+    #[serde(serialize_with = "serialize_nix_error")]
+    pub source: nix::Error,
+}
+
+#[derive(Debug, thiserror::Error, serde::Serialize)]
+pub enum FindModuleError {
+    #[error("Module not found")]
+    ModuleNotFound,
+    #[error("Failed to read process module mappings")]
+    MappingError(#[from] super::maps_reader::MapsReaderError),
+}
+
+pub struct ProcessReader {
+    /// The pid of the child to read
+    pid: nix::unistd::Pid,
+    style: OnceLock<Style>,
+}
+
+impl std::fmt::Debug for ProcessReader {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self.style.get() {
+            Some(Style::VirtualMem) => "process_vm_readv",
+            Some(Style::File(_)) => "/proc/<pid>/mem",
+            Some(Style::Ptrace) => "PTRACE_PEEKDATA",
+            Some(Style::Unavailable { vmem, file, ptrace }) => {
+                return write!(
+                    f,
+                    "process_vm_readv: {vmem}, /proc/<pid>/mem: {file}, PTRACE_PEEKDATA: {ptrace}"
+                );
+            }
+            None => "unknown",
+        };
+
+        f.write_str(s)
+    }
+}
+
+impl ProcessReader {
+    /// Creates a [`Self`] for the specified process id, the method used will
+    /// be probed for on the first access
+    #[inline]
+    pub fn new(pid: ProcessHandle) -> Self {
+        Self {
+            pid: nix::unistd::Pid::from_raw(pid),
+            style: OnceLock::default(),
+        }
+    }
+
+    #[inline]
+    #[doc(hidden)]
+    pub fn for_virtual_mem(pid: i32) -> Self {
+        Self {
+            pid: nix::unistd::Pid::from_raw(pid),
+            style: OnceLock::from(Style::VirtualMem),
+        }
+    }
+
+    #[inline]
+    #[doc(hidden)]
+    pub fn for_file(pid: i32) -> std::io::Result<Self> {
+        let file = std::fs::File::open(format!("/proc/{pid}/mem"))?;
+
+        Ok(Self {
+            pid: nix::unistd::Pid::from_raw(pid),
+            style: OnceLock::from(Style::File(file)),
+        })
+    }
+
+    #[inline]
+    #[doc(hidden)]
+    pub fn for_ptrace(pid: i32) -> Self {
+        Self {
+            pid: nix::unistd::Pid::from_raw(pid),
+            style: OnceLock::from(Style::Ptrace),
+        }
+    }
+
+    /// Read memory from the process into the given buffer.
+    ///
+    /// Returns the number of bytes read.
+    pub fn read(&self, src: usize, dst: &mut [u8]) -> Result<usize, CopyFromProcessError> {
+        if let Some(rs) = self.style.get() {
+            let res = match rs {
+                Style::VirtualMem => Self::vmem(self.pid, src, dst).map_err(|s| (s, 0)),
+                Style::File(file) => Self::file(file, src, dst).map_err(|s| (s, 0)),
+                Style::Ptrace => Self::ptrace(self.pid, src, dst),
+                Style::Unavailable { ptrace, .. } => Err((*ptrace, 0)),
+            };
+
+            return res.map_err(|(source, offset)| CopyFromProcessError {
+                child: self.pid.as_raw(),
+                src,
+                offset,
+                length: dst.len(),
+                source,
+            });
+        }
+
+        const DOUBLE_INIT_MSG: &str = "somehow MemReader initialized twice";
+
+        // Attempt to read in order of speed
+        let vmem = match Self::vmem(self.pid, src, dst) {
+            Ok(len) => {
+                self.style.set(Style::VirtualMem).expect(DOUBLE_INIT_MSG);
+                return Ok(len);
+            }
+            Err(err) => err,
+        };
+
+        let file = match std::fs::File::open(format!("/proc/{}/mem", self.pid)) {
+            Ok(file) => match Self::file(&file, src, dst) {
+                Ok(len) => {
+                    self.style.set(Style::File(file)).expect(DOUBLE_INIT_MSG);
+                    return Ok(len);
+                }
+                Err(err) => err,
+            },
+            Err(err) => nix::Error::from_raw(err.raw_os_error().expect(
+                "failed to open /proc/<pid>/mem and the I/O error doesn't have an OS code",
+            )),
+        };
+
+        let ptrace = match Self::ptrace(self.pid, src, dst) {
+            Ok(len) => {
+                self.style.set(Style::Ptrace).expect(DOUBLE_INIT_MSG);
+                return Ok(len);
+            }
+            Err((err, _)) => err,
+        };
+
+        self.style
+            .set(Style::Unavailable { vmem, file, ptrace })
+            .expect(DOUBLE_INIT_MSG);
+        Err(CopyFromProcessError {
+            child: self.pid.as_raw(),
+            src,
+            offset: 0,
+            length: dst.len(),
+            source: ptrace,
+        })
+    }
+
+    #[inline]
+    fn vmem(pid: nix::unistd::Pid, src: usize, dst: &mut [u8]) -> Result<usize, nix::Error> {
+        let remote = &[nix::sys::uio::RemoteIoVec {
+            base: src,
+            len: dst.len(),
+        }];
+        nix::sys::uio::process_vm_readv(pid, &mut [std::io::IoSliceMut::new(dst)], remote)
+    }
+
+    #[inline]
+    fn file(file: &std::fs::File, src: usize, dst: &mut [u8]) -> Result<usize, nix::Error> {
+        use std::os::unix::fs::FileExt;
+
+        file.read_exact_at(dst, src as u64).map_err(|err| {
+            if let Some(os) = err.raw_os_error() {
+                nix::Error::from_raw(os)
+            } else {
+                nix::Error::E2BIG /* EOF */
+            }
+        })?;
+
+        Ok(dst.len())
+    }
+
+    #[inline]
+    fn ptrace(
+        pid: nix::unistd::Pid,
+        src: usize,
+        dst: &mut [u8],
+    ) -> Result<usize, (nix::Error, usize)> {
+        let mut offset = 0;
+        let mut chunks = dst.chunks_exact_mut(std::mem::size_of::<usize>());
+
+        for chunk in chunks.by_ref() {
+            let word = nix::sys::ptrace::read(pid, (src + offset) as *mut std::ffi::c_void)
+                .map_err(|err| (err, offset))?;
+            chunk.copy_from_slice(&word.to_ne_bytes());
+            offset += std::mem::size_of::<usize>();
+        }
+
+        // I don't think there would ever be a case where we would not read on word boundaries, but just in case...
+        let last = chunks.into_remainder();
+        if !last.is_empty() {
+            let word = nix::sys::ptrace::read(pid, (src + offset) as *mut std::ffi::c_void)
+                .map_err(|err| (err, offset))?;
+            last.copy_from_slice(&word.to_ne_bytes()[..last.len()]);
+        }
+
+        Ok(dst.len())
+    }
+
+    /// Find the address at which a module with the given name is loaded in the process.
+    pub fn find_module(&self, module_name: &str) -> Result<ModuleMemory<'_>, FindModuleError> {
+        MappingInfo::for_pid(self.pid.as_raw(), None)?
+            .into_iter()
+            .find_map(|m| {
+                let mmem = ModuleMemory::from_process(self, m.start_address);
+                let name = m.name.as_ref().and_then(|s| s.to_str())?;
+                if name == module_name {
+                    return Some(mmem);
+                }
+                // Check whether the SO_NAME matches the module name.
+                //
+                // For now, only check the SO_NAME of Android APKS, because libraries may be mapped
+                // directly from within an APK. See bug 1982902.
+                #[cfg(target_os = "android")]
+                if name.ends_with(".apk") {
+                    if let Ok(SoName(so_name)) = mmem.read_from_module() {
+                        if so_name == name {
+                            return Some(mmem);
+                        }
+                    }
+                }
+
+                None
+            })
+            .ok_or(FindModuleError::ModuleNotFound)
+    }
+}

--- a/src/mac/mod.rs
+++ b/src/mac/mod.rs
@@ -9,5 +9,7 @@ pub use mach2;
 pub mod errors;
 pub mod mach;
 pub mod minidump_writer;
+pub mod module_reader;
+pub mod process_reader;
 mod streams;
 pub mod task_dumper;

--- a/src/mac/module_reader.rs
+++ b/src/mac/module_reader.rs
@@ -1,0 +1,173 @@
+use crate::module_reader::{ModuleMemory, ModuleMemoryReadError};
+use crate::serializers::*;
+use goblin::container::{Container, Ctx, Endian};
+use goblin::mach::{
+    self,
+    header::{Header, Header64, MH_DYLIB, MH_EXECUTE, MH_MAGIC_64},
+    load_command::{LC_SEGMENT_64, LoadCommandHeader, Section64, SegmentCommand64},
+};
+use scroll::ctx::{SizeWith, TryFromCtx};
+
+const DATA_SEGMENT: &[u8; 16] = b"__DATA\0\0\0\0\0\0\0\0\0\0";
+
+pub struct ModuleReader<'a> {
+    module_memory: ModuleMemory<'a>,
+    header: Header,
+    context: Ctx,
+}
+
+#[derive(Debug, thiserror::Error, serde::Serialize)]
+pub enum ModuleReaderError {
+    #[error(transparent)]
+    ReadModuleMemory(#[from] ModuleMemoryReadError),
+    #[error("failed to parse MachO memory: {0}")]
+    GoblinParsing(
+        #[from]
+        #[serde(serialize_with = "serialize_generic_error")]
+        goblin::error::Error,
+    ),
+    #[error("failed to parse MachO memory: {0}")]
+    ScrollParsing(
+        #[from]
+        #[serde(serialize_with = "serialize_scroll_error")]
+        scroll::Error,
+    ),
+    #[error("failed to derive parsing context from MachO memory")]
+    MissingCtx,
+}
+
+macro_rules! read_scroll {
+    ( $T:ty , $mem:expr , $offset:expr , $ctx:expr ) => {{
+        let bytes = $mem.read($offset, <$T>::size_with(&$ctx) as u64)?;
+        let (value, _) = <$T>::try_from_ctx(bytes.as_ref(), $ctx)?;
+        value
+    }};
+}
+
+macro_rules! read_scroll_array {
+    ( $T:ty , $mem:expr , $offset:expr , $count:expr , $ctx:expr ) => {{
+        let bytes = $mem.read($offset, (<$T>::size_with(&$ctx) * $count) as u64)?;
+        let mut vals = Vec::with_capacity($count);
+        let mut offset = 0;
+        for _ in 0..$count {
+            let (value, bytes_read) = <$T>::try_from_ctx(&bytes[offset..], $ctx)?;
+            offset += bytes_read;
+            vals.push(value);
+        }
+        vals
+    }};
+}
+
+impl ModuleMemory<'_> {
+    /// Read an array of values using scroll traits.
+    ///
+    /// See `read_scroll` for an explanation of the return form.
+    #[inline]
+    pub fn read_scroll_array<T, Ctx, F, R, Error>(
+        &self,
+        offset: u64,
+        count: usize,
+        ctx: Ctx,
+        result: F,
+    ) -> Result<R, ModuleReaderError>
+    where
+        T: scroll::ctx::SizeWith<Ctx> + for<'b> scroll::ctx::TryFromCtx<'b, Ctx>,
+        Ctx: Copy,
+        F: for<'b> FnOnce(
+            Result<Vec<T>, <T as scroll::ctx::TryFromCtx<'b, Ctx>>::Error>,
+        ) -> Result<R, ModuleReaderError>,
+        Error: From<ModuleMemoryReadError>,
+    {
+        let bytes = self.read(offset, (T::size_with(&ctx) * count) as u64)?;
+        let mut vals = Vec::with_capacity(count);
+        let mut offset = 0;
+        for _ in 0..count {
+            let (value, bytes_read) = match T::try_from_ctx(&bytes[offset..], ctx) {
+                Ok(v) => v,
+                Err(e) => return result(Err(e)),
+            };
+            offset += bytes_read;
+            vals.push(value);
+        }
+        result(Ok(vals))
+    }
+}
+
+impl<'a> ModuleReader<'a> {
+    pub fn new(module_memory: ModuleMemory<'a>) -> Result<Self, ModuleReaderError> {
+        let header_size = Header::size_with(&Ctx::new(Container::Big, Endian::default()));
+        let header_data = module_memory.read(0, header_size as u64)?;
+        let (_, ctx) = mach::parse_magic_and_ctx(&header_data, 0)?;
+        let ctx = ctx.ok_or(ModuleReaderError::MissingCtx)?;
+        let (header, _) = Header::try_from_ctx(&header_data, ctx)?;
+        Ok(Self {
+            module_memory,
+            header,
+            context: ctx,
+        })
+    }
+
+    pub fn find_section(
+        &self,
+        section_name: &[u8; 16],
+    ) -> Result<Option<usize>, ModuleReaderError> {
+        if self.header.magic == MH_MAGIC_64
+            && (self.header.filetype == MH_EXECUTE || self.header.filetype == MH_DYLIB)
+        {
+            let mut offset = Header64::size_with(&self.context.le) as u64;
+            let end_of_commands = offset + self.header.sizeofcmds as u64;
+
+            while offset < end_of_commands {
+                let command = read_scroll!(
+                    LoadCommandHeader,
+                    &self.module_memory,
+                    offset,
+                    self.context.le
+                );
+
+                if command.cmd == LC_SEGMENT_64 {
+                    let result = self.find_section_in_segment(offset, section_name);
+                    if let Ok(Some(_)) = &result {
+                        return result;
+                    }
+                }
+
+                offset += command.cmdsize as u64;
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn find_section_in_segment(
+        &self,
+        segment_offset: u64,
+        section_name: &[u8; 16],
+    ) -> Result<Option<usize>, ModuleReaderError> {
+        let segment = read_scroll!(
+            SegmentCommand64,
+            &self.module_memory,
+            segment_offset,
+            self.context.le
+        );
+
+        if segment.segname.eq(DATA_SEGMENT) {
+            let sections_offset =
+                segment_offset + SegmentCommand64::size_with(&self.context.le) as u64;
+            let sections = read_scroll_array!(
+                Section64,
+                self.module_memory,
+                sections_offset,
+                segment.nsects as usize,
+                self.context.le
+            );
+            for section in &sections {
+                if section.sectname.eq(section_name) {
+                    return Ok(Some(section.offset as usize));
+                }
+            }
+        }
+
+        Ok(None)
+    }
+}

--- a/src/mac/process_reader.rs
+++ b/src/mac/process_reader.rs
@@ -1,0 +1,170 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::module_reader::ModuleMemory;
+use mach2::{
+    kern_return::KERN_SUCCESS,
+    task::task_info,
+    task_info::{TASK_DYLD_ALL_IMAGE_INFO_64, TASK_DYLD_INFO, task_dyld_info},
+    vm::mach_vm_read_overwrite,
+};
+use std::mem::{MaybeUninit, size_of};
+
+pub type ProcessHandle = mach2::mach_types::task_t;
+
+pub struct ProcessReader {
+    process: ProcessHandle,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+struct AllImagesInfo {
+    // VERSION 1
+    pub version: u32,
+    /// The number of [`ImageInfo`] structs at that following address
+    info_array_count: u32,
+    /// The address in the process where the array of [`ImageInfo`] structs is
+    info_array_addr: u64,
+    /// A function pointer, unused
+    _notification: u64,
+    /// Unused
+    _process_detached_from_shared_region: bool,
+    // VERSION 2
+    lib_system_initialized: bool,
+    // Note that crashpad adds a 32-bit int here to get proper alignment when
+    // building on 32-bit targets...but we explicitly don't care about 32-bit
+    // targets since Apple doesn't
+    pub dyld_image_load_address: u64,
+}
+
+/// `dyld_image_info` from <usr/include/mach-o/dyld_images.h>
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+struct ImageInfo {
+    /// The address in the process where the image is loaded
+    pub load_address: u64,
+    /// The address in the process where the image's file path can be read
+    pub file_path: u64,
+    /// Timestamp for when the image's file was last modified
+    pub file_mod_date: u64,
+}
+
+#[derive(Debug, thiserror::Error, serde::Serialize)]
+#[error("Copy from process {child} failed (source {src}, length: {length})")]
+pub struct CopyFromProcessError {
+    pub child: ProcessHandle,
+    pub src: usize,
+    pub length: usize,
+    pub kern_return: mach2::kern_return::kern_return_t,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum FindModuleError {
+    #[error("Failed to get task info")]
+    TaskInfoError,
+    #[error("The image is not a supported format")]
+    ImageFormatInvalid,
+    #[error("The module was not found")]
+    ModuleNotFound,
+    #[error("Failed to read data from the module")]
+    FailedToReadModule(#[from] CopyFromProcessError),
+}
+
+impl ProcessReader {
+    pub fn new(process: ProcessHandle) -> ProcessReader {
+        ProcessReader { process }
+    }
+
+    pub fn read(&self, src: usize, dst: &mut [u8]) -> Result<usize, CopyFromProcessError> {
+        let mut size: u64 = 0;
+        let res = unsafe {
+            mach_vm_read_overwrite(
+                self.process,
+                src as _,
+                dst.len() as _,
+                dst.as_mut_ptr() as _,
+                &mut size as _,
+            )
+        };
+
+        if res == KERN_SUCCESS {
+            Ok(size as usize)
+        } else {
+            Err(CopyFromProcessError {
+                child: self.process,
+                src,
+                length: dst.len(),
+                kern_return: res,
+            })
+        }
+    }
+
+    pub fn find_module(&self, module_name: &str) -> Result<ModuleMemory<'_>, FindModuleError> {
+        let dyld_info = self.task_info()?;
+        if (dyld_info.all_image_info_format as u32) != TASK_DYLD_ALL_IMAGE_INFO_64 {
+            return Err(FindModuleError::ImageFormatInvalid);
+        }
+
+        let all_image_info_size = dyld_info.all_image_info_size;
+        let all_image_info_addr = dyld_info.all_image_info_addr;
+        if (all_image_info_size as usize) < size_of::<AllImagesInfo>() {
+            return Err(FindModuleError::ImageFormatInvalid);
+        }
+
+        // SAFETY: The values of AllImagesInfo can be arbitrary; if they are incorrect (e.g. bad
+        // addresses), bounds checking will produce an appropriate error.
+        let all_images_info =
+            unsafe { self.copy_object::<AllImagesInfo>(all_image_info_addr as _) }?;
+
+        // Load the images
+        // SAFETY: ImageInfo is allowed to have arbitrary values: if they are not valid, it will be
+        // caught later.
+        let images = unsafe {
+            self.copy_array::<ImageInfo>(
+                all_images_info.info_array_addr as _,
+                all_images_info.info_array_count as _,
+            )
+        }?;
+
+        images
+            .iter()
+            .find(|&image| {
+                let image_path = self.copy_nul_terminated_string(image.file_path as usize);
+
+                if let Ok(image_path) = image_path {
+                    if let Some(image_name) = image_path.into_bytes().rsplit(|&b| b == b'/').next()
+                    {
+                        image_name.eq(module_name.as_bytes())
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                }
+            })
+            .map(|image| ModuleMemory::from_process(self, image.load_address as usize))
+            .ok_or(FindModuleError::ModuleNotFound)
+    }
+
+    fn task_info(&self) -> Result<task_dyld_info, FindModuleError> {
+        let mut info = MaybeUninit::<task_dyld_info>::uninit();
+        let mut count = (size_of::<task_dyld_info>() / size_of::<u32>()) as u32;
+
+        let res = unsafe {
+            task_info(
+                self.process,
+                TASK_DYLD_INFO,
+                info.as_mut_ptr().cast(),
+                &mut count,
+            )
+        };
+
+        if res == KERN_SUCCESS {
+            // SAFETY: this will be initialized if the call succeeded
+            unsafe { Ok(info.assume_init()) }
+        } else {
+            Err(FindModuleError::TaskInfoError)
+        }
+    }
+}

--- a/src/module_reader.rs
+++ b/src/module_reader.rs
@@ -1,0 +1,124 @@
+//! Common module reader types.
+use {
+    crate::process_reader::{CopyFromProcessError, ProcessReader},
+    std::borrow::Cow,
+};
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub use crate::linux::module_reader::*;
+
+#[cfg(target_os = "windows")]
+pub use crate::windows::module_reader::*;
+
+#[cfg(target_os = "macos")]
+pub use crate::mac::module_reader::*;
+
+/// Module memory, which may either be represented by a slice or by an offset into a process's
+/// address space.
+#[derive(Clone, Copy)]
+pub enum ModuleMemory<'a> {
+    Slice(&'a [u8]),
+    Process {
+        reader: &'a ProcessReader,
+        start_address: u64,
+    },
+}
+
+impl<'buf> From<&'buf [u8]> for ModuleMemory<'buf> {
+    fn from(value: &'buf [u8]) -> Self {
+        Self::Slice(value)
+    }
+}
+
+#[derive(Debug, thiserror::Error, serde::Serialize)]
+#[error("Error reading {length} bytes at {offset:#x}{}: {error}",
+    .start_address.map(|s| format!(" (module start address {s:#x})")).unwrap_or_default()
+)]
+pub struct ModuleMemoryReadError {
+    offset: u64,
+    length: u64,
+    start_address: Option<u64>,
+    #[source]
+    error: ReadError,
+}
+
+#[derive(Debug, thiserror::Error, serde::Serialize)]
+pub enum ReadError {
+    #[error("Attempted to read 0 bytes from process memory")]
+    ZeroLengthProcessRead,
+    #[error("Read overflowed the address space")]
+    Overflow,
+    #[error("Read was out of slice memory bounds")]
+    OutOfBounds,
+    #[error(transparent)]
+    CopyError(#[from] CopyFromProcessError),
+}
+
+impl<'a> ModuleMemory<'a> {
+    pub fn from_process(reader: &'a ProcessReader, start_address: usize) -> Self {
+        Self::Process {
+            reader,
+            start_address: start_address as u64,
+        }
+    }
+
+    #[inline]
+    pub fn read(&self, offset: u64, length: u64) -> Result<Cow<'a, [u8]>, ModuleMemoryReadError> {
+        let error = move |start_address, error| ModuleMemoryReadError {
+            start_address,
+            offset,
+            length,
+            error,
+        };
+
+        match self {
+            Self::Process {
+                reader,
+                start_address,
+            } => {
+                let error = |e| error(Some(*start_address), e);
+                let len = std::num::NonZeroUsize::new(length as usize)
+                    .ok_or_else(|| error(ReadError::ZeroLengthProcessRead))?;
+                let proc_offset = start_address
+                    .checked_add(offset)
+                    .ok_or_else(|| error(ReadError::Overflow))?;
+                reader
+                    .read_to_vec(proc_offset as _, len)
+                    .map(Cow::Owned)
+                    .map_err(|err| error(err.into()))
+            }
+            Self::Slice(s) => {
+                let error = |e| error(None, e);
+                let end = offset
+                    .checked_add(length)
+                    .ok_or_else(|| error(ReadError::Overflow))?;
+                s.get(offset as usize..end as usize)
+                    .map(Cow::Borrowed)
+                    .ok_or_else(|| error(ReadError::OutOfBounds))
+            }
+        }
+    }
+
+    /// Calculates the relative address of the specified absolute address
+    #[inline]
+    pub fn absolute_to_relative(&self, addr: u64) -> Option<u64> {
+        let Self::Process { start_address, .. } = self else {
+            return Some(addr);
+        };
+        addr.checked_sub(*start_address)
+    }
+
+    /// Calculates the absolute address of the specified relative address
+    #[inline]
+    pub fn relative_to_absolute(&self, addr: u64) -> Option<u64> {
+        let Self::Process { start_address, .. } = self else {
+            return Some(addr);
+        };
+        start_address.checked_add(addr)
+    }
+
+    #[inline]
+    pub fn is_process_memory(&self) -> bool {
+        matches!(self, Self::Process { .. })
+    }
+}

--- a/src/process_reader.rs
+++ b/src/process_reader.rs
@@ -1,0 +1,229 @@
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub use crate::linux::process_reader::*;
+
+#[cfg(target_os = "windows")]
+pub use crate::windows::process_reader::*;
+
+#[cfg(target_os = "macos")]
+pub use crate::mac::process_reader::*;
+
+use std::{ffi::CString, mem::MaybeUninit};
+
+impl ProcessReader {
+    #[inline]
+    pub fn read_to_vec(
+        &self,
+        src: usize,
+        length: std::num::NonZeroUsize,
+    ) -> Result<Vec<u8>, CopyFromProcessError> {
+        let mut output = vec![0u8; length.into()];
+        let bytes_read = self.read(src, &mut output)?;
+        output.truncate(bytes_read);
+        Ok(output)
+    }
+
+    #[inline]
+    pub fn read_all(&self, src: usize, dst: &mut [u8]) -> Result<(), CopyFromProcessError> {
+        let mut offset = 0;
+        while offset < dst.len() {
+            offset += self.read(src + offset, &mut dst[offset..])?;
+        }
+        Ok(())
+    }
+
+    #[inline]
+    pub fn read_all_to_vec(
+        &self,
+        src: usize,
+        length: usize,
+    ) -> Result<Vec<u8>, CopyFromProcessError> {
+        let mut output = vec![0u8; length];
+        self.read_all(src, &mut output)?;
+        Ok(output)
+    }
+
+    pub fn copy_nul_terminated_string(
+        &self,
+        address: usize,
+    ) -> Result<CString, CopyFromProcessError> {
+        // Try copying the string word-by-word first, this is considerably
+        // faster than one byte at a time.
+        if let Ok(string) = self.copy_nul_terminated_string_word_by_word(address) {
+            return Ok(string);
+        }
+
+        // Reading the string one word at a time failed, let's try again one
+        // byte at a time. It's slow but it might work in situations where the
+        // string alignment causes word-by-word access to straddle page
+        // boundaries.
+        let mut string = Vec::<u8>::new();
+        let mut c = 1u8;
+
+        while c != 0 {
+            self.read(address + string.len(), std::slice::from_mut(&mut c))?;
+            string.push(c);
+        }
+
+        // SAFETY: If we reach this point we've read at least one byte and we
+        // know that the last one we read is nul.
+        Ok(unsafe { CString::from_vec_with_nul_unchecked(string) })
+    }
+
+    fn copy_nul_terminated_string_word_by_word(
+        &self,
+        address: usize,
+    ) -> Result<CString, CopyFromProcessError> {
+        const WORD_SIZE: usize = size_of::<usize>();
+        let mut string = Vec::<u8>::new();
+        let mut word_bytes = [0u8; WORD_SIZE];
+
+        loop {
+            let read_byte_len = self.read(address + string.len(), &mut word_bytes)?;
+            // SAFETY: at most WORD_SIZE bytes are indexed
+            let mut read_bytes =
+                unsafe { word_bytes.get_unchecked(..std::cmp::min(read_byte_len, WORD_SIZE)) };
+            let nul_terminator = read_bytes.iter().position(|&e| e == 0);
+            if let Some(nul_terminator) = nul_terminator {
+                // +1 to include the nul terminator
+                read_bytes = &read_bytes[..nul_terminator + 1];
+            }
+            string.extend(read_bytes);
+
+            if nul_terminator.is_some() {
+                break;
+            }
+        }
+
+        // SAFETY: If we reach this point we've read at least one byte and we
+        // know that the last one we read is nul.
+        Ok(unsafe { CString::from_vec_with_nul_unchecked(string) })
+    }
+
+    #[inline]
+    pub fn copy_object_uninit<T>(
+        &self,
+        src: usize,
+    ) -> Result<MaybeUninit<T>, CopyFromProcessError> {
+        let mut object = MaybeUninit::<T>::uninit();
+        self.read_all(src, uninit_as_bytes_mut(&mut object))?;
+        Ok(object)
+    }
+
+    /// # Safety
+    /// The caller must ensure that the object will be in an initialized, valid state.
+    #[inline]
+    pub unsafe fn copy_object<T>(&self, src: usize) -> Result<T, CopyFromProcessError> {
+        self.copy_object_uninit(src)
+            .map(|object| unsafe { object.assume_init() })
+    }
+
+    #[inline]
+    pub fn copy_array_uninit<T>(
+        &self,
+        src: usize,
+        num: usize,
+    ) -> Result<Vec<MaybeUninit<T>>, CopyFromProcessError> {
+        let mut v = Vec::with_capacity(num);
+        for _ in 0..num {
+            v.push(MaybeUninit::<T>::uninit());
+        }
+        self.read_all(src, uninit_slice_as_bytes_mut(&mut v))?;
+        Ok(v)
+    }
+
+    /// # Safety
+    /// The caller must ensure that the objects will be in an initialized, valid state.
+    #[inline]
+    pub unsafe fn copy_array<T>(
+        &self,
+        src: usize,
+        num: usize,
+    ) -> Result<Vec<T>, CopyFromProcessError> {
+        self.copy_array_uninit(src, num)
+            .map(|v| unsafe { std::mem::transmute::<Vec<MaybeUninit<T>>, Vec<T>>(v) })
+    }
+}
+
+fn uninit_as_bytes_mut<T>(elem: &mut MaybeUninit<T>) -> &mut [u8] {
+    // SAFETY: elem is at least size_of::<T>() bytes, and MaybeUninit<T> has no validity guarantees
+    // (so providing a mutable slice of bytes is sound)
+    unsafe { std::slice::from_raw_parts_mut(elem.as_mut_ptr() as *mut u8, size_of::<T>()) }
+}
+
+fn uninit_slice_as_bytes_mut<T>(slice: &mut [MaybeUninit<T>]) -> &mut [u8] {
+    // SAFETY: the slice is at least size_of::<T>()*len() bytes, and MaybeUninit<T> has no validity
+    // guarantees (so providing a mutable slice of bytes is sound)
+    unsafe {
+        std::slice::from_raw_parts_mut(slice.as_mut_ptr() as *mut u8, size_of::<T>() * slice.len())
+    }
+}
+
+/*
+#[derive(Debug, Error)]
+pub enum ProcessReaderError {
+    #[error("Could not convert address {0}")]
+    ConvertAddressError(#[from] std::num::TryFromIntError),
+    #[error("Could not parse address {0}")]
+    ParseAddressError(#[from] std::num::ParseIntError),
+    #[cfg(target_os = "windows")]
+    #[error("Cannot enumerate the target process's modules")]
+    EnumProcessModulesError,
+    #[error("goblin failed to parse a module")]
+    GoblinError(#[from] goblin::error::Error),
+    #[error("Address was out of bounds")]
+    InvalidAddress,
+    #[error("Could not read from the target process address space")]
+    ReadFromProcessError(#[from] ReadError),
+    #[cfg(any(target_os = "windows", target_os = "macos"))]
+    #[error("Section was not found")]
+    SectionNotFound,
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[error("Could not attach to the target process")]
+    AttachError(#[from] PtraceError),
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[error("Note not found")]
+    NoteNotFound,
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[error("SONAME not found")]
+    SoNameNotFound,
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[error("waitpid() failed when attaching to the process")]
+    WaitPidError,
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[error("Could not parse a line in /proc/<pid>/maps")]
+    ProcMapsParseError,
+    #[error("Module not found")]
+    ModuleNotFound,
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[error("IO error for file {0}")]
+    IOError(#[from] std::io::Error),
+    #[cfg(target_os = "macos")]
+    #[error("Failure when requesting the task information")]
+    TaskInfoError,
+    #[cfg(target_os = "macos")]
+    #[error("The task dyld information format is unknown or invalid")]
+    ImageFormatError,
+}
+
+#[derive(Debug, Error)]
+pub enum ReadError {
+    #[cfg(target_os = "macos")]
+    #[error("mach call failed")]
+    MachError,
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[error("ptrace-specific error")]
+    PtraceError(#[from] PtraceError),
+    #[cfg(target_os = "windows")]
+    #[error("ReadProcessMemory failed")]
+    ReadProcessMemoryError,
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+#[derive(Debug, Error)]
+pub enum PtraceError {
+    #[error("Could not read from the target process address space")]
+    ReadError(#[source] std::io::Error),
+    #[error("Could not trace the process")]
+    TraceError(#[source] std::io::Error),
+}
+*/

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -4,3 +4,5 @@ mod ffi;
 
 pub mod errors;
 pub mod minidump_writer;
+pub mod module_reader;
+pub mod process_reader;

--- a/src/windows/module_reader.rs
+++ b/src/windows/module_reader.rs
@@ -1,0 +1,57 @@
+use {
+    crate::{
+        module_reader::{ModuleMemory, ModuleMemoryReadError},
+        serializers::*,
+    },
+    goblin::pe::header::Header,
+    std::borrow::Cow,
+};
+
+pub struct ModuleReader<'a> {
+    first_page: Cow<'a, [u8]>,
+}
+
+#[derive(Debug, thiserror::Error, serde::Serialize)]
+pub enum ModuleReaderError {
+    #[error(transparent)]
+    ReadModuleMemory(#[from] ModuleMemoryReadError),
+    #[error("failed to parse PE memory: {0}")]
+    GoblinParsing(
+        #[from]
+        #[serde(serialize_with = "serialize_generic_error")]
+        goblin::error::Error,
+    ),
+}
+
+impl<'a> ModuleReader<'a> {
+    pub fn new(module_memory: ModuleMemory<'a>) -> Result<Self, ModuleReaderError> {
+        // We read only the first page from the module, this should be more than
+        // enough to read the header and section list. In the future we might do
+        // this incrementally but for now goblin requires an array to parse
+        // so we can't do it just yet.
+        const PAGE_SIZE: u64 = 4096;
+        let bytes = module_memory.read(0, PAGE_SIZE)?;
+
+        Ok(Self { first_page: bytes })
+    }
+
+    pub fn find_section(&self, section_name: &[u8; 8]) -> Result<Option<usize>, ModuleReaderError> {
+        let header = Header::parse(&self.first_page)?;
+        // Skip the PE header so we can parse the sections
+        let optional_header_offset = header.dos_header.pe_pointer as usize
+            + goblin::pe::header::SIZEOF_PE_MAGIC
+            + goblin::pe::header::SIZEOF_COFF_HEADER;
+        let offset =
+            &mut (optional_header_offset + header.coff_header.size_of_optional_header as usize);
+
+        let sections = header.coff_header.sections(&self.first_page, offset)?;
+
+        for section in sections {
+            if section.name.eq(section_name) {
+                return Ok(Some(section.virtual_address as usize));
+            }
+        }
+
+        Ok(None)
+    }
+}

--- a/src/windows/process_reader.rs
+++ b/src/windows/process_reader.rs
@@ -1,0 +1,164 @@
+use {
+    crate::{module_reader::ModuleMemory, serializers::*},
+    std::{
+        convert::TryInto,
+        ffi::OsString,
+        mem::{MaybeUninit, size_of},
+        os::windows::ffi::OsStringExt,
+    },
+    windows_sys::Win32::{
+        Foundation::{FALSE, HMODULE, MAX_PATH},
+        System::{
+            Diagnostics::Debug::ReadProcessMemory,
+            ProcessStatus::{
+                K32EnumProcessModules, K32GetModuleBaseNameW, K32GetModuleInformation, MODULEINFO,
+            },
+        },
+    },
+};
+
+pub type ProcessHandle = windows_sys::Win32::Foundation::HANDLE;
+
+pub struct ProcessReader {
+    process: ProcessHandle,
+}
+
+#[derive(Debug, thiserror::Error, serde::Serialize)]
+#[error("Copy from process {child} failed (source {src}, length: {length})")]
+pub struct CopyFromProcessError {
+    pub child: ProcessHandle,
+    pub src: usize,
+    pub length: usize,
+    #[serde(serialize_with = "serialize_io_error")]
+    pub error: std::io::Error,
+}
+
+#[derive(Debug, thiserror::Error, serde::Serialize)]
+pub enum FindModuleError {
+    #[error("Module not found")]
+    ModuleNotFound,
+    #[error("Failed to enumerator process modules")]
+    EnumProcessModulesError,
+    #[error("Module list exceeds 32-bit size constraint")]
+    ModuleListTooLarge,
+}
+
+impl ProcessReader {
+    pub fn new(process: ProcessHandle) -> ProcessReader {
+        ProcessReader { process }
+    }
+
+    pub fn read(&self, src: usize, dst: &mut [u8]) -> Result<usize, CopyFromProcessError> {
+        let mut size: usize = 0;
+        let res = unsafe {
+            ReadProcessMemory(
+                self.process,
+                src as _,
+                dst.as_mut_ptr() as _,
+                dst.len(),
+                &mut size,
+            )
+        };
+
+        if res != FALSE {
+            Ok(size)
+        } else {
+            Err(CopyFromProcessError {
+                child: self.process,
+                src,
+                length: dst.len(),
+                error: std::io::Error::last_os_error(),
+            })
+        }
+    }
+
+    pub fn find_module(&self, module_name: &str) -> Result<ModuleMemory<'_>, FindModuleError> {
+        let modules = self.get_module_list()?;
+
+        let module = modules.iter().find_map(|&module| {
+            let name = self.get_module_name(module);
+            // Crude way of mimicking Windows lower-case comparisons but
+            // sufficient for our use-cases.
+            if name.is_some_and(|name| name.eq_ignore_ascii_case(module_name)) {
+                self.get_module_info(module)
+                    .map(|module| module.lpBaseOfDll as usize)
+            } else {
+                None
+            }
+        });
+
+        module
+            .map(|m| ModuleMemory::from_process(self, m))
+            .ok_or(FindModuleError::ModuleNotFound)
+    }
+
+    fn get_module_list(&self) -> Result<Vec<HMODULE>, FindModuleError> {
+        let mut module_num: usize = 100;
+        let mut required_buffer_size: u32 = 0;
+        let mut module_array = Vec::<HMODULE>::with_capacity(module_num);
+
+        loop {
+            let buffer_size: u32 = (module_num * size_of::<HMODULE>())
+                .try_into()
+                .map_err(|_| FindModuleError::ModuleListTooLarge)?;
+            let res = unsafe {
+                K32EnumProcessModules(
+                    self.process,
+                    module_array.as_mut_ptr() as *mut _,
+                    buffer_size,
+                    &mut required_buffer_size as *mut _,
+                )
+            };
+
+            module_num = required_buffer_size as usize / size_of::<HMODULE>();
+
+            if required_buffer_size > buffer_size {
+                module_array = Vec::<HMODULE>::with_capacity(module_num);
+            } else if res == 0 {
+                return Err(FindModuleError::EnumProcessModulesError);
+            } else {
+                break;
+            }
+        }
+
+        // SAFETY: module_array has been filled by K32EnumProcessModules()
+        unsafe {
+            module_array.set_len(module_num);
+        };
+
+        Ok(module_array)
+    }
+
+    fn get_module_name(&self, module: HMODULE) -> Option<String> {
+        let mut path: [u16; MAX_PATH as usize] = [0; MAX_PATH as usize];
+        let res =
+            unsafe { K32GetModuleBaseNameW(self.process, module, path.as_mut_ptr(), MAX_PATH) };
+
+        if res == 0 {
+            None
+        } else {
+            let name = OsString::from_wide(&path[0..res as usize]);
+            let name = name.to_str()?;
+            Some(name.to_string())
+        }
+    }
+
+    fn get_module_info(&self, module: HMODULE) -> Option<MODULEINFO> {
+        let mut info: MaybeUninit<MODULEINFO> = MaybeUninit::uninit();
+        let res = unsafe {
+            K32GetModuleInformation(
+                self.process,
+                module,
+                info.as_mut_ptr(),
+                size_of::<MODULEINFO>() as u32,
+            )
+        };
+
+        if res == 0 {
+            None
+        } else {
+            let info = unsafe { info.assume_init() };
+            Some(info)
+        }
+    }
+}

--- a/tests/linux_module_reader.rs
+++ b/tests/linux_module_reader.rs
@@ -22,21 +22,21 @@ const TINY_ELF: &[u8] = include_bytes!("tiny.elf");
 
 #[test]
 fn build_id_program_headers() {
-    let mut reader = ModuleReader::new(TINY_ELF.into()).unwrap();
+    let reader = ModuleReader::new(TINY_ELF.into()).unwrap();
     let id = reader.build_id_from_program_headers().unwrap();
     assert_eq!(id, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
 }
 
 #[test]
 fn build_id_section() {
-    let mut reader = ModuleReader::new(TINY_ELF.into()).unwrap();
+    let reader = ModuleReader::new(TINY_ELF.into()).unwrap();
     let id = reader.build_id_from_section().unwrap();
     assert_eq!(id, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
 }
 
 #[test]
 fn build_id_text_hash() {
-    let mut reader = ModuleReader::new(TINY_ELF.into()).unwrap();
+    let reader = ModuleReader::new(TINY_ELF.into()).unwrap();
     let id = reader.build_id_generate_from_text().unwrap();
     assert_eq!(
         id,
@@ -48,14 +48,14 @@ fn build_id_text_hash() {
 
 #[test]
 fn soname_program_headers() {
-    let mut reader = ModuleReader::new(TINY_ELF.into()).unwrap();
+    let reader = ModuleReader::new(TINY_ELF.into()).unwrap();
     let soname = reader.soname_from_program_headers().unwrap();
     assert_eq!(soname, "libfoo.so.1");
 }
 
 #[test]
 fn soname_section() {
-    let mut reader = ModuleReader::new(TINY_ELF.into()).unwrap();
+    let reader = ModuleReader::new(TINY_ELF.into()).unwrap();
     let soname = reader.soname_from_sections().unwrap();
     assert_eq!(soname, "libfoo.so.1");
 }

--- a/tests/ptrace_dumper.rs
+++ b/tests/ptrace_dumper.rs
@@ -82,7 +82,7 @@ fn thread_list_from_child() {
         }
 
         act.sa_flags = libc::SA_SIGINFO;
-        act.sa_sigaction = on_sig as usize;
+        act.sa_sigaction = on_sig as *const () as _;
 
         // Register the action with the signal handler
         if libc::sigaction(libc::SIGHUP, &act, std::ptr::null_mut()) != 0 {


### PR DESCRIPTION
This merges features from the firefox process_reader crate for [bug 1831094](https://bugzilla.mozilla.org/show_bug.cgi?id=1831094), in a step toward using `minidump-writer` to read crash annotations on its own.