### PR TITLE
chore: bump crash-context to 0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "crash-context"
-version = "0.6.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031ed29858d90cfdf27fe49fae28028a1f20466db97962fa2f4ea34809aeebf3"
+checksum = "bae4a1220f7f921ffa2085a2dea382acb43c8353e374939bd2f42a28ad9547dc"
 dependencies = [
  "cfg-if",
  "libc",
@@ -475,7 +475,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -567,7 +567,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2021,7 +2021,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2491,7 +2491,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ license.workspace = true
 [dependencies]
 bitflags = "2.10"
 cfg-if = "1.0"
-crash-context = "0.6"
+crash-context = "0.7"
 error-graph = { version = "0.1.1", features = ["serde"] }
 failspot = "0.2.0"
 # goblin >= 0.10 uses scroll 0.13


### PR DESCRIPTION
crash-context introduce a macos related fixes