### PR TITLE
Prepare process-reader and process-backend for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1672,7 +1672,7 @@ dependencies = [
 
 [[package]]
 name = "process-backend"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "libc",
  "log",
@@ -1683,7 +1683,7 @@ dependencies = [
 
 [[package]]
 name = "process-reader"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "libc",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ memmap2 = "0.9"
 byteorder = "1.4"
 error-graph = { version = "0.1.1", features = ["serde"] }
 failspot = "0.2.0"
-process-backend = { path = "crates/linux/process-backend", features = ["testing"] }
+process-backend = { version = "0.1.0", path = "crates/linux/process-backend", features = ["testing"] }
 
 # Used for parsing procfs info.
 # default-features is disabled since it pulls in chrono

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ license = "MIT"
 [workspace.dependencies]
 # Note this functionality is now available in std in 1.95.0
 cfg-if = "1.0"
-libc = "0.2"
+libc = { version = "0.2", default-features = false }
 log = "0.4"
 mach2 = "0.6"
 serde = { version = "1.0.208", default-features = false, features = ["derive"] }

--- a/crates/linux/process-backend/CHANGELOG.md
+++ b/crates/linux/process-backend/CHANGELOG.md
@@ -1,0 +1,16 @@
+<!-- markdownlint-disable blanks-around-headings blanks-around-lists no-duplicate-heading -->
+
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+<!-- next-header -->
+## [Unreleased] - ReleaseDate
+### Added
+- Initial release.
+
+<!-- next-url -->
+[Unreleased]: https://github.com/rust-minidump/minidump-writer/compare/process-backend-0.1.0...HEAD
+[0.1.0]: https://github.com/rust-minidump/minidump-writer/releases/tag/process-backend-0.1.0

--- a/crates/linux/process-backend/Cargo.toml
+++ b/crates/linux/process-backend/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "process-backend"
-version = "0.0.0"
+version = "0.1.0"
 repository.workspace = true
 homepage.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 
+[features]
+testing = []
+
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 libc.workspace = true
 log.workspace = true
-process-reader = { path = "../../process-reader", features = ["serde"] }
+process-reader = { version = "0.1.0", path = "../../process-reader", features = ["serde"] }
 serde.workspace = true
 thiserror.workspace = true
-
-[features]
-testing = []

--- a/crates/linux/process-backend/LICENSE
+++ b/crates/linux/process-backend/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/linux/process-backend/release.toml
+++ b/crates/linux/process-backend/release.toml
@@ -1,0 +1,10 @@
+pre-release-commit-message = "Release process-backend-{{version}}"
+tag-message = "Release process-backend-{{version}}"
+tag-name = "process-backend-{{version}}"
+pre-release-replacements = [
+    { file = "CHANGELOG.md", search = "Unreleased", replace = "{{version}}" },
+    { file = "CHANGELOG.md", search = "\\.\\.\\.HEAD", replace = "...{{tag_name}}" },
+    { file = "CHANGELOG.md", search = "ReleaseDate", replace = "{{date}}" },
+    { file = "CHANGELOG.md", search = "<!-- next-header -->", replace = "<!-- next-header -->\n## [Unreleased] - ReleaseDate" },
+    { file = "CHANGELOG.md", search = "<!-- next-url -->", replace = "<!-- next-url -->\n[Unreleased]: https://github.com/rust-minidump/minidump-writer/compare/{{tag_name}}...HEAD" },
+]

--- a/crates/process-reader/CHANGELOG.md
+++ b/crates/process-reader/CHANGELOG.md
@@ -1,0 +1,16 @@
+<!-- markdownlint-disable blanks-around-headings blanks-around-lists no-duplicate-heading -->
+
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+<!-- next-header -->
+## [Unreleased] - ReleaseDate
+### Added
+- Initial release.
+
+<!-- next-url -->
+[Unreleased]: https://github.com/rust-minidump/minidump-writer/compare/process-reader-0.1.0...HEAD
+[0.1.0]: https://github.com/rust-minidump/minidump-writer/releases/tag/process-reader-0.1.0

--- a/crates/process-reader/Cargo.toml
+++ b/crates/process-reader/Cargo.toml
@@ -1,14 +1,16 @@
 [package]
 name = "process-reader"
-version = "0.0.0"
-edition = "2024"
-rust-version = "1.88.0"
-license = "MIT"
+version = "0.1.0"
+repository.workspace = true
+homepage.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
 readme = "README.md"
-
-[target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
-libc = { version = "0.2.186", default-features = false }
-serde = { version = "1.0.228", default-features = false, features=["derive"], optional = true }
 
 [features]
 serde = ["dep:serde"]
+
+[target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
+libc = { workspace = true, default-features = false }
+serde = { version = "1.0.228", default-features = false, features = ["derive"], optional = true }

--- a/crates/process-reader/LICENSE
+++ b/crates/process-reader/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/process-reader/release.toml
+++ b/crates/process-reader/release.toml
@@ -1,0 +1,10 @@
+pre-release-commit-message = "Release process-reader-{{version}}"
+tag-message = "Release process-reader-{{version}}"
+tag-name = "process-reader-{{version}}"
+pre-release-replacements = [
+    { file = "CHANGELOG.md", search = "Unreleased", replace = "{{version}}" },
+    { file = "CHANGELOG.md", search = "\\.\\.\\.HEAD", replace = "...{{tag_name}}" },
+    { file = "CHANGELOG.md", search = "ReleaseDate", replace = "{{date}}" },
+    { file = "CHANGELOG.md", search = "<!-- next-header -->", replace = "<!-- next-header -->\n## [Unreleased] - ReleaseDate" },
+    { file = "CHANGELOG.md", search = "<!-- next-url -->", replace = "<!-- next-url -->\n[Unreleased]: https://github.com/rust-minidump/minidump-writer/compare/{{tag_name}}...HEAD" },
+]


### PR DESCRIPTION
Belatedly realized I couldn't make a new release of minidump-writer because these 2 new dependencies haven't been released.