### PR TITLE
tests: allow testing on arm64 Android emulators

### DIFF
--- a/.cargo/android-runner.sh
+++ b/.cargo/android-runner.sh
@@ -3,7 +3,11 @@
 BINARY=$1
 shift
 
+# Cargo doesn't expose the target triple to the runner, so derive it from the
+# binary path (.../target/<triple>/...).
+TARGET=$(printf '%s' "$BINARY" | sed -E 's#(.*/)?target/([^/]+)/.*#\2#')
+
 # Make sure to run the following to copy the test helper binary over.
-# cargo run --target x86_64-linux-android --bin test
+# cargo run --target "$TARGET" --bin test
 adb push "$BINARY" "/data/local/$BINARY"
-adb shell "chmod 777 /data/local/$BINARY && env TEST_HELPER=/data/local/target/x86_64-linux-android/debug/test /data/local/$BINARY" "$@"
+adb shell "chmod 777 /data/local/$BINARY && env TEST_HELPER=/data/local/target/$TARGET/debug/test /data/local/$BINARY" "$@"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -14,3 +14,9 @@ linker = "x86_64-linux-android30-clang"
 # By default the linker _doesn't_ generate a build-id, however we want one for our tests.
 rustflags = ["-C", "link-args=-Wl,--build-id=sha1"]
 runner = [".cargo/android-runner.sh"]
+
+[target.aarch64-linux-android]
+linker = "aarch64-linux-android30-clang"
+# By default the linker _doesn't_ generate a build-id, however we want one for our tests.
+rustflags = ["-C", "link-args=-Wl,--build-id=sha1"]
+runner = [".cargo/android-runner.sh"]

--- a/src/linux/dumper_cpu_info/arm.rs
+++ b/src/linux/dumper_cpu_info/arm.rs
@@ -1,6 +1,7 @@
 use {
     super::{CpuInfoError, ProcessInspector},
     crate::minidump_format::*,
+    failspot::failspot,
     scroll::Pwrite,
     std::{
         collections::HashSet,
@@ -191,14 +192,13 @@ pub fn write_cpu_information(
     // readable from regular Android applications on later versions
     // (>= 4.1) of the Android platform.
 
-    let cpuinfo_file = match process_inspector.read_file("/proc/cpuinfo") {
-        Ok(x) => x,
-        Err(_) => {
-            // Do not return Error here to allow the minidump generation
-            // to happen properly.
-            return Ok(());
-        }
-    };
+    if failspot!(CpuInfoFileOpen) {
+        process_inspector.fail_one_syscall_with(libc::EPERM);
+    }
+
+    let cpuinfo_file = process_inspector
+        .read_file("/proc/cpuinfo")
+        .map_err(CpuInfoError::ReadFileError)?;
 
     let mut cpuid = 0;
     let mut elf_hwcaps = 0;


### PR DESCRIPTION
This is notably useful when using an Apple Silicon machine for development.