### PR TITLE
CI: ARM native tests and platform-specific Clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt,clippy
+      - name: targets
+        run: rustup target list --installed | grep aarch64
       - name: rustfmt
         run: cargo fmt --all -- --check
       - name: clippy
@@ -43,10 +45,13 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           target: ${{ matrix.job.target }}
+          components: clippy
       - name: Fetch
         run: cargo fetch --target ${{ matrix.job.target }}
       - name: Build
         run: cargo test --target ${{ matrix.job.target }} --no-run
+      - name: Clippy
+        run: cargo clippy --all-features --all-targets --target ${{ matrix.job.target }} -- -D warnings
       - name: Test
         run: cargo test --target ${{ matrix.job.target }}
       - name: Release test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt,clippy
-      - name: targets
-        run: rustup target list --installed | grep aarch64
       - name: rustfmt
         run: cargo fmt --all -- --check
       - name: clippy
@@ -36,6 +34,7 @@ jobs:
         job:
           - { os: ubuntu-24.04,   target: x86_64-unknown-linux-gnu, release: true }
           - { os: ubuntu-24.04,   target: x86_64-unknown-linux-musl }
+          - { os: ubuntu-24.04-arm,   target: aarch64-unknown-linux-gnu }
           - { os: windows-2025,   target: x86_64-pc-windows-msvc }
           - { os: macos-15-intel, target: x86_64-apple-darwin }
           - { os: macos-15,       target: aarch64-apple-darwin }
@@ -84,7 +83,6 @@ jobs:
       matrix:
         job:
           - target: i686-unknown-linux-gnu
-          - target: aarch64-unknown-linux-gnu
           - target: aarch64-unknown-linux-musl
           - target: arm-unknown-linux-gnueabi
           - target: arm-unknown-linux-musleabi

--- a/src/linux/dumper_cpu_info/arm.rs
+++ b/src/linux/dumper_cpu_info/arm.rs
@@ -273,10 +273,10 @@ pub fn write_cpu_information(
         }
 
         // Rebuild the ELF hwcaps from the 'Features' field.
-        if field == "Features" {
-            if let Some(val) = value {
-                elf_hwcaps = parse_features(val);
-            }
+        if field == "Features"
+            && let Some(val) = value
+        {
+            elf_hwcaps = parse_features(val);
         }
     }
 

--- a/src/mac/streams/module_list.rs
+++ b/src/mac/streams/module_list.rs
@@ -372,7 +372,7 @@ mod test {
             let expect_segment_data = unsafe {
                 getsegmentdata(
                     expected_img_hdr,
-                    b"__TEXT\0".as_ptr(),
+                    c"__TEXT".as_ptr().cast(),
                     &mut expect_segment_size,
                 )
             };

--- a/tests/mac_minidump_writer.rs
+++ b/tests/mac_minidump_writer.rs
@@ -7,6 +7,7 @@ use {
         MinidumpModuleList, MinidumpSystemInfo, MinidumpThreadList,
     },
     minidump_writer::minidump_writer::MinidumpWriter,
+    std::os::unix::process::ExitStatusExt,
 };
 
 mod common;
@@ -67,6 +68,11 @@ fn capture_minidump(name: &str, exception_kind: u32) -> Captured<'_> {
         .expect("failed to send ack");
 
     child.kill().expect("failed to kill child");
+    // Reap child
+    let waitres = child.wait().expect("Failed to wait for child");
+    let status = waitres.signal().expect("Child did not die due to signal");
+    assert_eq!(waitres.code(), None);
+    assert_eq!(status, libc::SIGKILL);
 
     let minidump = Minidump::read_path(tmpfile.path()).expect("failed to read minidump");
 

--- a/tests/windows_minidump_writer.rs
+++ b/tests/windows_minidump_writer.rs
@@ -171,7 +171,11 @@ fn dump_external_process() {
         .expect("failed to write minidump");
 
     child.kill().expect("failed to kill child");
+    // Reap child
+    child.wait().expect("Failed to wait for child");
 
+    // Clean up the zombie child.
+    child.wait().expect("failed to wait child");
     let md = Minidump::read_path(tmpfile.path()).expect("failed to read minidump");
 
     let _: MinidumpThreadList = md.get_stream().expect("Couldn't find MinidumpThreadList");


### PR DESCRIPTION
This PR adds Linux arm64 in the set of main targets (GH has had runners for a while now), and runs clippy for all those main targets rather than just for x86_64-unknown-linux-gnu, since we have a sizable amount of platform-specific code that deserves to be checked.

And of course, bundled in are the various clippy fixes for the new failures those changes brought forward.