### PR TITLE
linux: change some APIs to use mem address rather than mapping index

### DIFF
--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -177,20 +177,17 @@ mod linux {
         let exe_link = format!("/proc/{ppid}/exe");
         let exe_name = std::fs::read_link(exe_link)?.into_os_string();
 
-        let mut dumper = fail_on_soft_error!(
+        let dumper = fail_on_soft_error!(
             soft_errors,
             MinidumpWriterConfig::new(ppid, ppid).build_for_testing(&mut soft_errors)?
         );
 
-        let mut found_exe = None;
-        for (idx, mapping) in dumper.mappings.iter().enumerate() {
-            if mapping.name.as_ref().map(|x| x.into()).as_ref() == Some(&exe_name) {
-                found_exe = Some(idx);
-                break;
-            }
-        }
-        let idx = found_exe.unwrap();
-        let id = dumper.build_id_from_process_memory_for_index(idx)?;
+        let exe_mapping = dumper
+            .mappings
+            .iter()
+            .find(|mapping| mapping.name.as_ref().map(|x| x.into()).as_ref() == Some(&exe_name))
+            .unwrap();
+        let id = dumper.build_id_from_process_memory(exe_mapping.start_address)?;
 
         drop(dumper);
 
@@ -226,24 +223,19 @@ mod linux {
 
     fn test_linux_gate_mapping_id() -> Result<()> {
         let ppid = getppid();
-        let mut dumper = fail_on_soft_error!(
+        let dumper = fail_on_soft_error!(
             soft_errors,
             MinidumpWriterConfig::new(ppid, ppid).build_for_testing(&mut soft_errors)?
         );
-        let mut found_linux_gate = false;
-        for idx in 0..dumper.mappings.len() {
-            if dumper.mappings[idx].name == Some(LINUX_GATE_LIBRARY_NAME.into()) {
-                found_linux_gate = true;
+        let linux_gate = dumper
+            .mappings
+            .iter()
+            .find(|mapping| mapping.name == Some(LINUX_GATE_LIBRARY_NAME.into()));
+        test!(linux_gate.is_some(), "found no linux_gate");
 
-                let id = dumper.build_id_from_process_memory_for_index(idx)?;
-
-                test!(!id.is_empty(), "id-vec is empty");
-                test!(id.iter().any(|&x| x > 0), "all id elements are 0");
-                drop(dumper);
-                break;
-            }
-        }
-        test!(found_linux_gate, "found no linux_gate");
+        let id = dumper.build_id_from_process_memory(linux_gate.unwrap().start_address)?;
+        test!(!id.is_empty(), "id-vec is empty");
+        test!(id.iter().any(|&x| x > 0), "all id elements are 0");
         Ok(())
     }
 

--- a/src/linux/minidump_writer/mappings.rs
+++ b/src/linux/minidump_writer/mappings.rs
@@ -20,25 +20,23 @@ impl MinidumpWriter {
         let mut modules = Vec::new();
 
         // First write all the mappings from the dumper
-        for map_idx in 0..self.mappings.len() {
+        for mapping in &self.mappings {
             // If the mapping is uninteresting, or if
             // there is caller-provided information about this mapping
             // in the user_mapping_list list, skip it
 
-            if !self.mappings[map_idx].is_interesting()
-                || self.mappings[map_idx].is_contained_in(&self.user_mapping_list)
-            {
+            if !mapping.is_interesting() || mapping.is_contained_in(&self.user_mapping_list) {
                 continue;
             }
-            log::debug!("retrieving build id for {:?}", self.mappings[map_idx]);
+            log::debug!("retrieving build id for {:?}", mapping);
             let identifier = self
-            .build_id_from_process_memory_for_index(map_idx)
+            .build_id_from_process_memory(mapping.start_address)
             .or_else(|e| {
                 // If the mapping has an associated name that is a file, try to read the build id
                 // from the file. If there is no note segment with the build id in
                 // the program headers, we can't get to the note section if the section header
                 // table isn't loaded.
-                let Some(path) = &self.mappings[map_idx].name else {
+                let Some(path) = &mapping.name else {
                     return Err(e);
                 };
 
@@ -58,12 +56,12 @@ impl MinidumpWriter {
 
             // SONAME should always be accessible through program headers alone, so we don't really
             // need to fall back to trying to read from the mapping file.
-            let soname = self.soname_from_process_memory_for_index(map_idx).ok();
+            let soname = self.soname_from_process_memory(mapping.start_address).ok();
 
             let module = fill_raw_module(
                 &self.process_inspector,
                 buffer,
-                &self.mappings[map_idx],
+                mapping,
                 &identifier,
                 soname,
             )?;

--- a/src/linux/minidump_writer/mod.rs
+++ b/src/linux/minidump_writer/mod.rs
@@ -917,26 +917,25 @@ impl MinidumpWriter {
         })
     }
 
-    pub fn build_id_from_process_memory_for_index(
-        &mut self,
-        idx: usize,
+    /// Reads the build ID out of the ELF object loaded at `start_address`.
+    pub fn build_id_from_process_memory(
+        &self,
+        start_address: usize,
     ) -> Result<Vec<u8>, WriterError> {
         let reader = self.process_inspector.process_reader();
         module_reader::read_build_id_from_module(module_reader::ProcessModuleMemoryReader::new(
             &reader,
-            self.mappings[idx].start_address,
+            start_address,
         ))
         .map_err(WriterError::ModuleReaderError)
     }
 
-    pub fn soname_from_process_memory_for_index(
-        &mut self,
-        idx: usize,
-    ) -> Result<String, WriterError> {
+    /// Reads the `DT_SONAME` out of the ELF object loaded at `start_address`.
+    pub fn soname_from_process_memory(&self, start_address: usize) -> Result<String, WriterError> {
         let reader = self.process_inspector.process_reader();
         module_reader::read_soname_from_module(module_reader::ProcessModuleMemoryReader::new(
             &reader,
-            self.mappings[idx].start_address,
+            start_address,
         ))
         .map_err(WriterError::ModuleReaderError)
     }


### PR DESCRIPTION
Those APIs are used to get data that's typically module-related, so having them take in an index into the *mappings* list can get pretty awkward once we start separating those concerns.

As a bonus, I find the client code to be more readable, although YMMV.

Split off #195 (I'm running out of small pieces I can spin out independently, sadly)