### PR TITLE
Make process-backend and process-reader private crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1661,7 +1661,7 @@ dependencies = [
 
 [[package]]
 name = "process-backend"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "libc",
  "process-reader",
@@ -1671,7 +1671,7 @@ dependencies = [
 
 [[package]]
 name = "process-reader"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "libc",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ memmap2 = "0.9"
 byteorder = "1.4"
 error-graph = { version = "0.1.1", features = ["serde"] }
 failspot = "0.2.0"
-process-backend = { version = "0.1.0", path = "crates/linux/process-backend", features = ["testing"] }
+process-backend = { path = "crates/linux/process-backend", features = ["testing"] }
 
 # Used for parsing procfs info.
 # default-features is disabled since it pulls in chrono

--- a/crates/linux/process-backend/Cargo.toml
+++ b/crates/linux/process-backend/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "process-backend"
-version = "0.1.0"
+version = "0.0.0"
+publish = false
 description = "Providers helpers for reading process memory specialized for minidump-writer"
 repository.workspace = true
 homepage.workspace = true
@@ -13,6 +14,6 @@ testing = []
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 libc.workspace = true
-process-reader = { version = "0.1.0", path = "../../process-reader", features = ["serde"] }
+process-reader = { path = "../../process-reader", features = ["serde"] }
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/process-reader/Cargo.toml
+++ b/crates/process-reader/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "process-reader"
-version = "0.1.0"
+version = "0.0.0"
+publish = false
 description = "Utilities for reading process memory on Linux"
 repository.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
These two crates were accidentally released on crates.io because we forgot to add the "publish = false" option to Cargo.toml. They are internal crates to minidump-writer and aren't really meant for public consumption, so it's unfortunate to have made that mistake.

This prevents us from accidentally doing this in the future.

(Note that, eventually, we may actually release `process-reader` as an independently-useful crate for the community... But it needs to be buffed up a bit before it's ready for that).